### PR TITLE
Demo content config files for content type and taxonomy creation on module install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # drupal-sapi2-prototype-demo
-Demo example code for drupal-sapi2-prototype
+Demo example code for drupal-sapi2-prototype 

--- a/sapi_demo/config/install/core.entity_form_display.node.demo_article.default.yml
+++ b/sapi_demo/config/install/core.entity_form_display.node.demo_article.default.yml
@@ -1,4 +1,3 @@
-uuid: 86515302-478c-4e8e-9c22-0affaa075a44
 langcode: en
 status: true
 dependencies:

--- a/sapi_demo/config/install/core.entity_form_display.node.demo_article.default.yml
+++ b/sapi_demo/config/install/core.entity_form_display.node.demo_article.default.yml
@@ -1,0 +1,70 @@
+uuid: 86515302-478c-4e8e-9c22-0affaa075a44
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.demo_article.body
+    - field.field.node.demo_article.field_colors
+    - node.type.demo_article
+  module:
+    - path
+    - text
+id: node.demo_article.default
+targetEntityType: node
+bundle: demo_article
+mode: default
+content:
+  body:
+    type: text_textarea_with_summary
+    weight: 31
+    settings:
+      rows: 9
+      summary_rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  created:
+    type: datetime_timestamp
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+  field_colors:
+    weight: 32
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+  path:
+    type: path
+    weight: 30
+    settings: {  }
+    third_party_settings: {  }
+  promote:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 15
+    third_party_settings: {  }
+  sticky:
+    type: boolean_checkbox
+    settings:
+      display_label: true
+    weight: 16
+    third_party_settings: {  }
+  title:
+    type: string_textfield
+    weight: -5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/sapi_demo/config/install/core.entity_view_display.node.demo_article.default.yml
+++ b/sapi_demo/config/install/core.entity_view_display.node.demo_article.default.yml
@@ -1,4 +1,3 @@
-uuid: c76667ed-66f6-4428-8431-1d28fec5655a
 langcode: en
 status: true
 dependencies:

--- a/sapi_demo/config/install/core.entity_view_display.node.demo_article.default.yml
+++ b/sapi_demo/config/install/core.entity_view_display.node.demo_article.default.yml
@@ -1,0 +1,32 @@
+uuid: c76667ed-66f6-4428-8431-1d28fec5655a
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.node.demo_article.body
+    - field.field.node.demo_article.field_colors
+    - node.type.demo_article
+  module:
+    - text
+    - user
+id: node.demo_article.default
+targetEntityType: node
+bundle: demo_article
+mode: default
+content:
+  body:
+    label: hidden
+    type: text_default
+    weight: 101
+    settings: {  }
+    third_party_settings: {  }
+  field_colors:
+    weight: 102
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  links:
+    weight: 100
+hidden: {  }

--- a/sapi_demo/config/install/core.entity_view_display.node.demo_article.teaser.yml
+++ b/sapi_demo/config/install/core.entity_view_display.node.demo_article.teaser.yml
@@ -1,0 +1,26 @@
+uuid: 4e1c876d-319b-4af4-8bc0-0efd00e0d03f
+langcode: en
+status: true
+dependencies:
+  config:
+    - core.entity_view_mode.node.teaser
+    - field.field.node.demo_article.body
+    - node.type.demo_article
+  module:
+    - text
+    - user
+id: node.demo_article.teaser
+targetEntityType: node
+bundle: demo_article
+mode: teaser
+content:
+  body:
+    label: hidden
+    type: text_summary_or_trimmed
+    weight: 101
+    settings:
+      trim_length: 600
+    third_party_settings: {  }
+  links:
+    weight: 100
+hidden: {  }

--- a/sapi_demo/config/install/core.entity_view_display.node.demo_article.teaser.yml
+++ b/sapi_demo/config/install/core.entity_view_display.node.demo_article.teaser.yml
@@ -1,4 +1,3 @@
-uuid: 4e1c876d-319b-4af4-8bc0-0efd00e0d03f
 langcode: en
 status: true
 dependencies:

--- a/sapi_demo/config/install/field.field.node.demo_article.body.yml
+++ b/sapi_demo/config/install/field.field.node.demo_article.body.yml
@@ -1,4 +1,3 @@
-uuid: 3df10cd4-e319-4261-b09d-0a0f9798dd94
 langcode: en
 status: true
 dependencies:

--- a/sapi_demo/config/install/field.field.node.demo_article.body.yml
+++ b/sapi_demo/config/install/field.field.node.demo_article.body.yml
@@ -1,0 +1,22 @@
+uuid: 3df10cd4-e319-4261-b09d-0a0f9798dd94
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.body
+    - node.type.demo_article
+  module:
+    - text
+id: node.demo_article.body
+field_name: body
+entity_type: node
+bundle: demo_article
+label: Body
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  display_summary: true
+field_type: text_with_summary

--- a/sapi_demo/config/install/field.field.node.demo_article.field_colors.yml
+++ b/sapi_demo/config/install/field.field.node.demo_article.field_colors.yml
@@ -1,0 +1,28 @@
+uuid: 23768b93-69ca-476c-ab4a-1bb47c9999dc
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_colors
+    - node.type.demo_article
+    - taxonomy.vocabulary.demo_colors
+id: node.demo_article.field_colors
+field_name: field_colors
+entity_type: node
+bundle: demo_article
+label: Colors
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      demo_colors: demo_colors
+    sort:
+      field: _none
+    auto_create: true
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/sapi_demo/config/install/field.field.node.demo_article.field_colors.yml
+++ b/sapi_demo/config/install/field.field.node.demo_article.field_colors.yml
@@ -1,4 +1,3 @@
-uuid: 23768b93-69ca-476c-ab4a-1bb47c9999dc
 langcode: en
 status: true
 dependencies:

--- a/sapi_demo/config/install/field.storage.node.field_colors.yml
+++ b/sapi_demo/config/install/field.storage.node.field_colors.yml
@@ -1,0 +1,20 @@
+uuid: bc9d06fd-671c-47ad-9231-e6753aff052e
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+    - taxonomy
+id: node.field_colors
+field_name: field_colors
+entity_type: node
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/sapi_demo/config/install/field.storage.node.field_colors.yml
+++ b/sapi_demo/config/install/field.storage.node.field_colors.yml
@@ -1,4 +1,3 @@
-uuid: bc9d06fd-671c-47ad-9231-e6753aff052e
 langcode: en
 status: true
 dependencies:

--- a/sapi_demo/config/install/node.type.demo_article.yml
+++ b/sapi_demo/config/install/node.type.demo_article.yml
@@ -1,4 +1,3 @@
-uuid: 6270ec38-0f68-4ccd-ba1d-d6cea6cd492a
 langcode: en
 status: true
 dependencies:

--- a/sapi_demo/config/install/node.type.demo_article.yml
+++ b/sapi_demo/config/install/node.type.demo_article.yml
@@ -1,0 +1,18 @@
+uuid: 6270ec38-0f68-4ccd-ba1d-d6cea6cd492a
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+name: Article
+type: demo_article
+description: ''
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: true

--- a/sapi_demo/config/install/node.type.demo_article.yml
+++ b/sapi_demo/config/install/node.type.demo_article.yml
@@ -8,9 +8,9 @@ third_party_settings:
     available_menus:
       - main
     parent: 'main:'
-name: Article
+name: Article (demo)
 type: demo_article
-description: ''
+description: 'A content type to demo the functionality of "sapi_demo" module.'
 help: ''
 new_revision: false
 preview_mode: 1

--- a/sapi_demo/config/install/node.type.demo_article.yml
+++ b/sapi_demo/config/install/node.type.demo_article.yml
@@ -1,8 +1,10 @@
 langcode: en
 status: true
 dependencies:
-  module:
-    - menu_ui
+  enforced:
+    module:
+      - sapi_demo
+      - menu_ui
 third_party_settings:
   menu_ui:
     available_menus:

--- a/sapi_demo/config/install/taxonomy.vocabulary.demo_colors.yml
+++ b/sapi_demo/config/install/taxonomy.vocabulary.demo_colors.yml
@@ -1,0 +1,9 @@
+uuid: 9788982d-f5ce-40fb-bccd-05b1a290bb75
+langcode: en
+status: true
+dependencies: {  }
+name: Colors
+vid: demo_colors
+description: ''
+hierarchy: 0
+weight: 0

--- a/sapi_demo/config/install/taxonomy.vocabulary.demo_colors.yml
+++ b/sapi_demo/config/install/taxonomy.vocabulary.demo_colors.yml
@@ -1,4 +1,3 @@
-uuid: 9788982d-f5ce-40fb-bccd-05b1a290bb75
 langcode: en
 status: true
 dependencies: {  }

--- a/sapi_demo/config/install/taxonomy.vocabulary.demo_colors.yml
+++ b/sapi_demo/config/install/taxonomy.vocabulary.demo_colors.yml
@@ -1,6 +1,13 @@
 langcode: en
 status: true
-dependencies: {  }
+dependencies:
+  enforced:
+    module:
+      - sapi_demo
+    config:
+      - field.field.node.demo_article.field_colors
+      - field.storage.node.field_colors
+      - node.type.demo_article
 name: Colors (demo)
 vid: demo_colors
 description: 'A taxonomy vocabulary to demo the functionality of "sapi_demo" module.'

--- a/sapi_demo/config/install/taxonomy.vocabulary.demo_colors.yml
+++ b/sapi_demo/config/install/taxonomy.vocabulary.demo_colors.yml
@@ -1,8 +1,8 @@
 langcode: en
 status: true
 dependencies: {  }
-name: Colors
+name: Colors (demo)
 vid: demo_colors
-description: ''
+description: 'A taxonomy vocabulary to demo the functionality of "sapi_demo" module.'
 hierarchy: 0
 weight: 0

--- a/sapi_demo/sapi_demo.info.yml
+++ b/sapi_demo/sapi_demo.info.yml
@@ -3,3 +3,6 @@ type: module
 description: Demo for statistics API module
 core: 8.x
 package: statistics
+dependencies:
+  - sapi
+  - sapi_data

--- a/sapi_demo/sapi_demo.info.yml
+++ b/sapi_demo/sapi_demo.info.yml
@@ -1,0 +1,5 @@
+name: Sapi Demo
+type: module
+description: Demo for statistics API module
+core: 8.x
+package: statistics

--- a/sapi_demo/sapi_demo.info.yml
+++ b/sapi_demo/sapi_demo.info.yml
@@ -1,8 +1,8 @@
-name: Sapi Demo
+name: Statistics API demo
 type: module
-description: Demo for statistics API module
+description: Demo for Statistics API module
 core: 8.x
-package: statistics
+package: Statistics
 dependencies:
   - sapi
   - sapi_data


### PR DESCRIPTION
Adds 8 files to create colors taxonomy vocabulary, demo article content type with color taxonomy reference field in it.

Trello card - https://trello.com/c/AVniwIi9/16-create-a-module-which-provides-a-content-type-and-taxonomy-vocabulary
