### PR TITLE
Created Color Frequency bundle and fields for it

### DIFF
--- a/sapi_demo/config/install/core.entity_form_display.sapi_data.color_frequency.default.yml
+++ b/sapi_demo/config/install/core.entity_form_display.sapi_data.color_frequency.default.yml
@@ -1,0 +1,65 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.sapi_data.color_frequency.field_color
+    - field.field.sapi_data.color_frequency.field_date
+    - field.field.sapi_data.color_frequency.field_frequency
+    - field.field.sapi_data.color_frequency.field_user
+    - sapi_data.sapi_data_type.color_frequency
+  module:
+    - datetime
+    - sapi_demo
+id: sapi_data.color_frequency.default
+targetEntityType: sapi_data
+bundle: color_frequency
+mode: default
+content:
+  field_color:
+    weight: 16
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+  field_date:
+    weight: 18
+    settings: {  }
+    third_party_settings: {  }
+    type: datetime_default
+  field_frequency:
+    weight: 15
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: number
+  field_user:
+    weight: 17
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+  langcode:
+    type: language_select
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -4
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  user_id:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/sapi_demo/config/install/core.entity_view_display.sapi_data.color_frequency.default.yml
+++ b/sapi_demo/config/install/core.entity_view_display.sapi_data.color_frequency.default.yml
@@ -1,0 +1,62 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.sapi_data.color_frequency.field_color
+    - field.field.sapi_data.color_frequency.field_date
+    - field.field.sapi_data.color_frequency.field_frequency
+    - field.field.sapi_data.color_frequency.field_user
+    - sapi_data.sapi_data_type.color_frequency
+  module:
+    - datetime
+    - user
+    - sapi_demo
+id: sapi_data.color_frequency.default
+targetEntityType: sapi_data
+bundle: color_frequency
+mode: default
+content:
+  field_color:
+    weight: 6
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  field_date:
+    weight: 8
+    label: above
+    settings:
+      format_type: medium
+      timezone_override: ''
+    third_party_settings: {  }
+    type: datetime_default
+  field_frequency:
+    weight: 5
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    type: number_integer
+  field_user:
+    weight: 7
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  name:
+    label: above
+    type: string
+    weight: -4
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  user_id:
+    label: hidden
+    type: author
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/sapi_demo/config/install/field.field.sapi_data.color_frequency.field_color.yml
+++ b/sapi_demo/config/install/field.field.sapi_data.color_frequency.field_color.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+   - sapi_demo
+  config:
+    - field.storage.sapi_data.field_color
+    - sapi_data.sapi_data_type.color_frequency
+    - taxonomy.vocabulary.demo_colors
+id: sapi_data.color_frequency.field_color
+field_name: field_color
+entity_type: sapi_data
+bundle: color_frequency
+label: Color
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:taxonomy_term'
+  handler_settings:
+    target_bundles:
+      demo_colors: demo_colors
+    sort:
+      field: _none
+    auto_create: false
+    auto_create_bundle: ''
+field_type: entity_reference

--- a/sapi_demo/config/install/field.field.sapi_data.color_frequency.field_date.yml
+++ b/sapi_demo/config/install/field.field.sapi_data.color_frequency.field_date.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.sapi_data.field_date
+    - sapi_data.sapi_data_type.color_frequency
+  module:
+    - datetime
+    - sapi_demo
+id: sapi_data.color_frequency.field_date
+field_name: field_date
+entity_type: sapi_data
+bundle: color_frequency
+label: Date
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: datetime

--- a/sapi_demo/config/install/field.field.sapi_data.color_frequency.field_frequency.yml
+++ b/sapi_demo/config/install/field.field.sapi_data.color_frequency.field_frequency.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - sapi_demo
+  config:
+    - field.storage.sapi_data.field_frequency
+    - sapi_data.sapi_data_type.color_frequency
+id: sapi_data.color_frequency.field_frequency
+field_name: field_frequency
+entity_type: sapi_data
+bundle: color_frequency
+label: Frequency
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/sapi_demo/config/install/field.field.sapi_data.color_frequency.field_user.yml
+++ b/sapi_demo/config/install/field.field.sapi_data.color_frequency.field_user.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - sapi_demo
+  config:
+    - field.storage.sapi_data.field_user
+    - sapi_data.sapi_data_type.color_frequency
+id: sapi_data.color_frequency.field_user
+field_name: field_user
+entity_type: sapi_data
+bundle: color_frequency
+label: User
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:user'
+  handler_settings:
+    include_anonymous: true
+    filter:
+      type: _none
+    target_bundles: null
+    sort:
+      field: _none
+    auto_create: false
+field_type: entity_reference

--- a/sapi_demo/config/install/field.storage.sapi_data.field_color.yml
+++ b/sapi_demo/config/install/field.storage.sapi_data.field_color.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - sapi_data
+    - taxonomy
+    - sapi_demo
+id: sapi_data.field_color
+field_name: field_color
+entity_type: sapi_data
+type: entity_reference
+settings:
+  target_type: taxonomy_term
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/sapi_demo/config/install/field.storage.sapi_data.field_date.yml
+++ b/sapi_demo/config/install/field.storage.sapi_data.field_date.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - datetime
+    - sapi_data
+    - sapi_demo
+id: sapi_data.field_date
+field_name: field_date
+entity_type: sapi_data
+type: datetime
+settings:
+  datetime_type: date
+module: datetime
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/sapi_demo/config/install/field.storage.sapi_data.field_frequency.yml
+++ b/sapi_demo/config/install/field.storage.sapi_data.field_frequency.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - sapi_data
+    - sapi_demo
+id: sapi_data.field_frequency
+field_name: field_frequency
+entity_type: sapi_data
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/sapi_demo/config/install/field.storage.sapi_data.field_user.yml
+++ b/sapi_demo/config/install/field.storage.sapi_data.field_user.yml
@@ -1,0 +1,21 @@
+uuid: 44309b53-28a3-4462-b5b5-96f4399dee28
+langcode: en
+status: true
+dependencies:
+  module:
+    - sapi_data
+    - user
+    - sapi_demo
+id: sapi_data.field_user
+field_name: field_user
+entity_type: sapi_data
+type: entity_reference
+settings:
+  target_type: user
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/sapi_demo/config/install/sapi_data.sapi_data_type.color_frequency.yml
+++ b/sapi_demo/config/install/sapi_data.sapi_data_type.color_frequency.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - sapi_demo
+id: color_frequency
+label: 'Color Frequency'


### PR DESCRIPTION
Created Color Frequency bundle and 4 fields for it:
- Color (taxonomy reference)
- Date 
- Frequency (integer)
- User (user reference)

After enabling sapi_demo module, under /admin/structure/sapi_data/add You will be able to add new content with these fields.

Trello card - https://trello.com/c/y9x7k33F/22-create-a-bundle-on-sapi-data-entity-type-with-fields
