### PR TITLE
Hook_uninstall removes color field on uninstall

### DIFF
--- a/sapi_demo/config/install/field.field.node.demo_article.field_colors.yml
+++ b/sapi_demo/config/install/field.field.node.demo_article.field_colors.yml
@@ -4,7 +4,6 @@ dependencies:
   config:
     - field.storage.node.field_colors
     - node.type.demo_article
-    - taxonomy.vocabulary.demo_colors
 id: node.demo_article.field_colors
 field_name: field_colors
 entity_type: node

--- a/sapi_demo/config/install/field.storage.node.field_colors.yml
+++ b/sapi_demo/config/install/field.storage.node.field_colors.yml
@@ -1,3 +1,4 @@
+uuid: bc9d06fd-671c-47ad-9231-e6753aff052e
 langcode: en
 status: true
 dependencies:

--- a/sapi_demo/config/install/field.storage.node.field_colors.yml
+++ b/sapi_demo/config/install/field.storage.node.field_colors.yml
@@ -1,4 +1,3 @@
-uuid: bc9d06fd-671c-47ad-9231-e6753aff052e
 langcode: en
 status: true
 dependencies:

--- a/sapi_demo/config/install/taxonomy.vocabulary.demo_colors.yml
+++ b/sapi_demo/config/install/taxonomy.vocabulary.demo_colors.yml
@@ -2,11 +2,7 @@ langcode: en
 status: true
 dependencies:
   enforced:
-    module:
-      - sapi_demo
     config:
-      - field.field.node.demo_article.field_colors
-      - field.storage.node.field_colors
       - node.type.demo_article
 name: Colors (demo)
 vid: demo_colors

--- a/sapi_demo/sapi_demo.install
+++ b/sapi_demo/sapi_demo.install
@@ -4,5 +4,6 @@
  * Implements hook_uninstall().
  */
 function sapi_demo_uninstall() {
+  // Remove field_colors field on uninstall.
   Drupal::configFactory()->getEditable('field.storage.node.field_colors')->delete();
 }

--- a/sapi_demo/sapi_demo.install
+++ b/sapi_demo/sapi_demo.install
@@ -1,0 +1,8 @@
+<?php
+
+/**
+ * Implements hook_uninstall().
+ */
+function sapi_demo_uninstall() {
+  Drupal::configFactory()->getEditable('field.storage.node.field_colors')->delete();
+}


### PR DESCRIPTION
Added sapi_demo.install file with hook_uninstall to remove field in database on uninstall.

Removed taxonomy.vocabulary.demo_colors dependency in field.field.node.demo_article.field_colors.yml and field.field.node.demo_article.field_colors field.storage.node.field_colors to avoid error with missing bundle on uninstall.

Trello-https://trello.com/c/AVniwIi9/16-create-a-module-which-provides-a-content-type-and-taxonomy-vocabulary
