### PR TITLE
Event subscriber added

### DIFF
--- a/sapi_demo/sapi_demo.services.yml
+++ b/sapi_demo/sapi_demo.services.yml
@@ -1,0 +1,6 @@
+services:
+  sapi_demo.request_view_subscriber:
+    class: Drupal\sapi_demo\EventSubscriber\RequestViewEventSubscriber
+    arguments: ['@sapi.dispatcher']
+    tags:
+      - { name: event_subscriber }

--- a/sapi_demo/src/EventSubscriber/RequestViewEventSubscriber.php
+++ b/sapi_demo/src/EventSubscriber/RequestViewEventSubscriber.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\sapi_demo\EventSubscriber;
+
+use Drupal\sapi\Dispatcher;
+use Drupal\sapi\StatisticsItem;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Class RequestViewEventSubscriber
+ */
+class RequestViewEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * The Statistics API dispatcher.
+   *
+   * @var \Drupal\sapi\Dispatcher $sapiDispatcher
+   */
+  protected $sapiDispatcher;
+
+  /**
+   * RequestViewEventSubscriber constructor.
+   *
+   * @param \Drupal\sapi\Dispatcher $sapiDispatcher
+   */
+  public function __construct(Dispatcher $sapiDispatcher) {
+    $this->sapiDispatcher = $sapiDispatcher;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  static function getSubscribedEvents() {
+    // Priority is set to 1 to avoid this listener from being stopped by other
+    // listeners.
+    // @see ContainerAwareEventDispatcher::dispatch()
+    $events[KernelEvents::VIEW][] = ['onRequestView', 1];
+    return $events;
+  }
+
+  /**
+   * Informs Statistics API dispatcher when controller outputs a value which is
+   * not a Response instance.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent $event
+   */
+  public function onRequestView(GetResponseForControllerResultEvent $event) {
+    try {
+      $this->sapiDispatcher->dispatch(new StatisticsItem('request_view', ''));
+    } catch (\Exception $e) {
+      watchdog_exception('sapi_demo', $e);
+    }
+  }
+
+}

--- a/sapi_demo/src/EventSubscriber/RequestViewEventSubscriber.php
+++ b/sapi_demo/src/EventSubscriber/RequestViewEventSubscriber.php
@@ -48,7 +48,7 @@ class RequestViewEventSubscriber implements EventSubscriberInterface {
    */
   public function onRequestView(GetResponseForControllerResultEvent $event) {
     try {
-      $this->sapiDispatcher->dispatch(new StatisticsItem('request_view', ''));
+      $this->sapiDispatcher->dispatch(new StatisticsItem('controller_view', ''));
     } catch (\Exception $e) {
       watchdog_exception('sapi_demo', $e);
     }


### PR DESCRIPTION
Statistics API dispatcher is sent an instance of `StatisticsItem` with action `controller_view` when `kernel.view` event is triggered. `kernel.view` event is triggered when value of the controller is not an instance of `Response`.

Statistics plugin can listen on `controller_view` action and get current route match using `\Drupal::routeMatch()`

Trello card: https://trello.com/c/LnF35S0y
