### PR TITLE
Demo sapi plugin to track node_color-user-date views in our sapi-data bundle

### DIFF
--- a/sapi_demo/sapi_demo.info.yml
+++ b/sapi_demo/sapi_demo.info.yml
@@ -6,3 +6,7 @@ package: Statistics
 dependencies:
   - sapi
   - sapi_data
+  - node
+  - taxonomy
+  - field
+  - datetime

--- a/sapi_demo/src/Plugin/StatisticsPlugin/ArticleColorTracker.php
+++ b/sapi_demo/src/Plugin/StatisticsPlugin/ArticleColorTracker.php
@@ -49,6 +49,16 @@ class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPlug
    */
   protected $currentUser;
 
+  /**
+   * ArticleColorTracker constructor.
+   *
+   * @param array $configuration
+   * @param string $plugin_id
+   * @param mixed $plugin_definition
+   * @param \Drupal\Core\Routing\RouteMatchInterface $routeMatch
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   * @param \Drupal\Core\Session\AccountProxyInterface $currentUser
+   */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $routeMatch, EntityTypeManagerInterface $entityTypeManager, AccountProxyInterface $currentUser) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
 
@@ -57,6 +67,9 @@ class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPlug
     $this->currentUser = $currentUser;
   }
 
+  /**
+   * {@inheritdoc}
+   */
   public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
     return new static(
       $configuration,

--- a/sapi_demo/src/Plugin/StatisticsPlugin/ArticleColorTracker.php
+++ b/sapi_demo/src/Plugin/StatisticsPlugin/ArticleColorTracker.php
@@ -8,11 +8,11 @@ use Drupal\sapi\StatisticsItemInterface;
 
 /**
  * @StatisticsPlugin(
- *  id = "article_colour_tracker",
+ *  id = "article_color_tracker",
  *  label = "Track article colour views"
  * )
  */
-class ArticleColourTracker extends StatisticsPluginBase implements StatisticsPluginInterface {
+class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPluginInterface {
 
   /**
    * EntityFieldQuery used to load the SAPI Data Items
@@ -51,9 +51,10 @@ class ArticleColourTracker extends StatisticsPluginBase implements StatisticsPlu
      *  retrieved using a \Drupal\Core\Entity\Query\QueryInterface
      */
     $results = $queryFactory->get('sapi_data')
-      ->condition('color', $color)
-      ->condition('user', $account)
-      ->condition('date', $date)
+      ->condition('type', 'color_frequency')
+      ->condition('field_color', $color)
+      ->condition('field_user', $account)
+//      ->condition('field_date', $date)
       ->execute();
 
     /** @var \Drupal\Core\Entity\EntityStorageInterface $entityStorageManager */
@@ -64,16 +65,21 @@ class ArticleColourTracker extends StatisticsPluginBase implements StatisticsPlu
     if (count($results)>0) {
       $entity_id = reset(array_keys($results));
       $sapiData = $entityStorageManager->load($entity_id);
-      $sapiData->set('frequency', $sapiData->get('frequency')+1);
+
+      $sapiData->field_frequency[0]->setValue(['value'=> $sapiData->field_frequency[0]->getValue()['value']+1]);
       $sapiData->save();
+
     }
     else {
+
       $entityStorageManager->create([
-        'color' => $color,
-        'user' => $account,
-        'date' => $date,
-        'frequency' => 1
+        'type' => 'color_frequency',
+        'field_color' => $color,
+        'field_user' => $account,
+        'field_date' => $date,
+        'field_frequency' => 1
       ])->save();
+
     }
 
   }

--- a/sapi_demo/src/Plugin/StatisticsPlugin/ArticleColorTracker.php
+++ b/sapi_demo/src/Plugin/StatisticsPlugin/ArticleColorTracker.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\sapi_demo\Plugin\StatisticsPlugin;
+
+use Drupal\sapi\Plugin\StatisticsPluginInterface;
+use Drupal\sapi\Plugin\StatisticsPluginBase;
+use Drupal\sapi\StatisticsItemInterface;
+
+/**
+ * @StatisticsPlugin(
+ *  id = "article_colour_tracker",
+ *  label = "Track article colour views"
+ * )
+ */
+class ArticleColourTracker extends StatisticsPluginBase implements StatisticsPluginInterface {
+
+  /**
+   * EntityFieldQuery used to load the SAPI Data Items
+   *
+   * @var \Drupal\Core\Entity\Query\QueryFactory
+   */
+  protected $entityFieldQuery;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function process(StatisticsItemInterface $item){
+
+    /**
+     * @var int $color
+     *   Term tid for the colour that we will track
+     */
+    $color = 1;
+    /**
+     * @var int $account
+     *   the uid for the user that we will track
+     */
+    $account = 1;
+    /**
+     * @var int $date
+     *  today's date, as a timestamp, but set to this morning.
+     */
+    $date = REQUEST_TIME;
+
+
+    /**  @var \Drupal\Core\Entity\Query\QueryFactory $queryFactory */
+    $queryFactory = \Drupal::service('entity.query');
+
+    /**
+     * @var array $results
+     *  retrieved using a \Drupal\Core\Entity\Query\QueryInterface
+     */
+    $results = $queryFactory->get('sapi_data')
+      ->condition('color', $color)
+      ->condition('user', $account)
+      ->condition('date', $date)
+      ->execute();
+
+    /** @var \Drupal\Core\Entity\EntityStorageInterface $entityStorageManager */
+    $entityStorageManager = \Drupal::service('entity_type.manager')->getStorage('sapi_data');
+
+    /** @var \Drupal\sapi_data\SAPIDataInterface $sapiData */
+
+    if (count($results)>0) {
+      $entity_id = reset(array_keys($results));
+      $sapiData = $entityStorageManager->load($entity_id);
+      $sapiData->set('frequency', $sapiData->get('frequency')+1);
+      $sapiData->save();
+    }
+    else {
+      $entityStorageManager->create([
+        'color' => $color,
+        'user' => $account,
+        'date' => $date,
+        'frequency' => 1
+      ])->save();
+    }
+
+  }
+
+}

--- a/sapi_demo/src/Plugin/StatisticsPlugin/ArticleColorTracker.php
+++ b/sapi_demo/src/Plugin/StatisticsPlugin/ArticleColorTracker.php
@@ -7,23 +7,19 @@ use Drupal\sapi\Plugin\StatisticsPluginBase;
 use Drupal\sapi\StatisticsItemInterface;
 
 /**
+ * This is a SAPI handler plugin used to track node views, and to count
+ * colour frequencies for the user/date, by looking at the node->field_colours
+ * value.
+ *
  * @StatisticsPlugin(
  *  id = "article_color_tracker",
  *  label = "Track article colour views"
  * )
  *
- *
  * @TODO currently route-id, item-action, and colour-field-name and logger id
  *   are all hardcoded strings.  These should be replaced or configured.
  */
 class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPluginInterface {
-
-  /**
-   * EntityFieldQuery used to load the SAPI Data Items
-   *
-   * @var \Drupal\Core\Entity\Query\QueryFactory
-   */
-  protected $entityFieldQuery;
 
   /**
    * {@inheritdoc}

--- a/sapi_demo/src/Plugin/StatisticsPlugin/ArticleColorTracker.php
+++ b/sapi_demo/src/Plugin/StatisticsPlugin/ArticleColorTracker.php
@@ -37,6 +37,7 @@ class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPlug
 
     /** @var \Drupal\Core\Routing\CurrentRouteMatch $route */
     $route = \Drupal::routeMatch();
+    // we will listen only to node canonical requests
     if ($route->getRouteName()!='entity.node.canonical') {
       return;
     }
@@ -61,7 +62,7 @@ class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPlug
 
     /**
      * @var int $color
-     *   Term tid for the colour that we will track
+     *   term tid for the colour that we will track
      */
     $color = $currentNode->get('field_colors')[0]->getValue()['target_id'];
 
@@ -74,6 +75,8 @@ class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPlug
     /**
      * @var int $date
      *  today's date, from a timestamp, but using only the day part.
+     *
+     * @see \Drupal\datetime\Plugin\Field\FieldType\DateTimeItem::generateSampleValue()
      */
     $date = gmdate(DATETIME_DATE_STORAGE_FORMAT, REQUEST_TIME);
 

--- a/sapi_demo/src/Plugin/StatisticsPlugin/ArticleColorTracker.php
+++ b/sapi_demo/src/Plugin/StatisticsPlugin/ArticleColorTracker.php
@@ -87,18 +87,17 @@ class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPlug
    */
   public function process(StatisticsItemInterface $item){
 
-    // We limit this action to only listening to one type of item action
-    if ($item->getAction() != 'controller_view') {
-      return;
-    }
-
-    // we will listen only to node canonical requests
-    if ($this->routeMatch->getRouteName()!='entity.node.canonical') {
-      return;
-    }
-
-    // we will not track anonymous user
-    if ($this->currentUser->isAnonymous()) {
+    /**
+     * Note we only track under the following circumstances:
+     *  - We limit this action to only listening to one type of item action
+     *  - we will listen only to node canonical requests
+     *  - we will not track anonymous user
+     */
+    if (
+        ($item->getAction() != 'controller_view')
+     || ($this->routeMatch->getRouteName()!='entity.node.canonical')
+     || $this->currentUser->isAnonymous()
+    ) {
       return;
     }
 

--- a/sapi_demo/src/Plugin/StatisticsPlugin/ArticleColorTracker.php
+++ b/sapi_demo/src/Plugin/StatisticsPlugin/ArticleColorTracker.php
@@ -99,8 +99,7 @@ class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPlug
       $entity_id = array_keys($results)[0];
 
       /** @var \Drupal\sapi_data\SAPIDataInterface $sapiData */
-      $sapiData = \Drupal
-        ::entityTypeManager()
+      $sapiData = \Drupal::entityTypeManager()
         ->getStorage('sapi_data')
         ->load($entity_id);
 
@@ -118,8 +117,7 @@ class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPlug
       /** Creating a new tracking entity */
 
       /** @var \Drupal\sapi_data\SAPIDataInterface $sapiData */
-      $sapiData = \Drupal
-        ::entityTypeManager()
+      $sapiData = \Drupal::entityTypeManager()
         ->getStorage('sapi_data')
         ->create([
             'type' => 'color_frequency',

--- a/sapi_demo/src/Plugin/StatisticsPlugin/ArticleColorTracker.php
+++ b/sapi_demo/src/Plugin/StatisticsPlugin/ArticleColorTracker.php
@@ -2,6 +2,12 @@
 
 namespace Drupal\sapi_demo\Plugin\StatisticsPlugin;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+use Drupal\Core\Session\AccountProxyInterface;
 use Drupal\sapi\Plugin\StatisticsPluginInterface;
 use Drupal\sapi\Plugin\StatisticsPluginBase;
 use Drupal\sapi\StatisticsItemInterface;
@@ -19,7 +25,49 @@ use Drupal\sapi\StatisticsItemInterface;
  * @TODO currently route-id, item-action, and colour-field-name and logger id
  *   are all hardcoded strings.  These should be replaced or configured.
  */
-class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPluginInterface {
+class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPluginInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * Route match object as we only track on certain routes
+   *
+   * @protected \Drupal\Core\Routing\RouteMatchInterface $routeMatch
+   */
+  protected $routeMatch;
+
+  /**
+   * EntityTypeManager used to get entity storage for sapi_data items, which is
+   * used to create and edit sapi_data items from tracking.
+   *
+   * @protected Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * Current user for tracking
+   *
+   * @protected Drupal\Core\Session\AccountProxyInterface $currentUser;
+   */
+  protected $currentUser;
+
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, RouteMatchInterface $routeMatch, EntityTypeManagerInterface $entityTypeManager, AccountProxyInterface $currentUser) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->routeMatch = $routeMatch;
+    $this->entityTypeManager = $entityTypeManager;
+    $this->currentUser = $currentUser;
+  }
+
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+
+      $container->get('current_route_match'),
+      $container->get('entity_type.manager'),
+      $container->get('current_user')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -31,22 +79,18 @@ class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPlug
       return;
     }
 
-    /** @var \Drupal\Core\Routing\CurrentRouteMatch $route */
-    $route = \Drupal::routeMatch();
     // we will listen only to node canonical requests
-    if ($route->getRouteName()!='entity.node.canonical') {
+    if ($this->routeMatch->getRouteName()!='entity.node.canonical') {
       return;
     }
 
-    /** @var \Drupal\Core\Session\AccountProxyInterface $currentUser */
-    $currentUser = \Drupal::currentUser();
     // we will not track anonymous user
-    if ($currentUser->isAnonymous()) {
+    if ($this->currentUser->isAnonymous()) {
       return;
     }
 
     /** @var \Drupal\node\NodeInterface|null $currentNode */
-    $currentNode = $route->getParameter('node');
+    $currentNode = $this->routeMatch->getParameter('node');
     // parameter sanity check and color field check
     if (
         is_null($currentNode)
@@ -66,7 +110,7 @@ class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPlug
      * @var int $account
      *   the uid for the user that we will track
      */
-    $account = $currentUser->id();
+    $account = $this->currentUser->id();
 
     /**
      * @var int $date
@@ -77,14 +121,27 @@ class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPlug
     $date = gmdate(DATETIME_DATE_STORAGE_FORMAT, REQUEST_TIME);
 
     /**
+     * We use the entity storage a few times, so we shortcut it here.
+     * It is used to:
+     *   - give a query to search for existing items
+     *   - load an existing item if found
+     *   - create a new item if needed
+     *
+     * @var EntityStorageInterface $sapiDataStorage
+     */
+    $sapiDataStorage = $this->entityTypeManager->getStorage('sapi_data');
+
+    /**
      * Use EntityQuery to search for a matching color_frequency data
      * item "color-user-date".  This will tell us if we need to create
      * a new one, or update an existing one.
      *
      * @var array $results
-     *  retrieved using a \Drupal\Core\Entity\Query\QueryInterface
+     *
+     *  retrieved using a \Drupal\Core\Entity\Query\QueryInterface which came
+     *  from the Query Factory
      */
-    $results = \Drupal::entityQuery('sapi_data')
+    $results = $sapiDataStorage->getQuery()
       ->condition('type', 'color_frequency')
       ->condition('field_color', $color)
       ->condition('field_user', $account)
@@ -98,9 +155,7 @@ class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPlug
       $entity_id = array_keys($results)[0];
 
       /** @var \Drupal\sapi_data\SAPIDataInterface $sapiData */
-      $sapiData = \Drupal::entityTypeManager()
-        ->getStorage('sapi_data')
-        ->load($entity_id);
+      $sapiData = $sapiDataStorage->load($entity_id);
 
       /** @var \Drupal\Core\Field\FIeldItemInterface $fieldFrequency */
       $fieldFrequency =& $sapiData->get('field_frequency')[0];
@@ -116,15 +171,13 @@ class ArticleColorTracker extends StatisticsPluginBase implements StatisticsPlug
       /** Creating a new tracking entity */
 
       /** @var \Drupal\sapi_data\SAPIDataInterface $sapiData */
-      $sapiData = \Drupal::entityTypeManager()
-        ->getStorage('sapi_data')
-        ->create([
-            'type' => 'color_frequency',
-            'field_color' => $color,
-            'field_user' => $account,
-            'field_date' => $date,
-            'field_frequency' => 1
-          ]);
+      $sapiData = $sapiDataStorage->create([
+        'type' => 'color_frequency',
+        'field_color' => $color,
+        'field_user' => $account,
+        'field_date' => $date,
+        'field_frequency' => 1
+      ]);
 
       if (!$sapiData->save()) {
         \Drupal::logger('sapi')->warning('Could not create SAPI data');


### PR DESCRIPTION
This patch adds a new custom SAPI handler plugin to the sapi_demo module, which listens for StatisticsItems of action "controller_view". If the current route points to a node canonical page for a node with a color field, the plugin will track the view, but creating or updating a "color_frequency" SAPI Data entity, incrementing the frequency.
### Interface

The plugin has no UI, but it should show up in the sapi plugin settings page.
The plugin emits no signals on success, but does log failures to save SAPI data entities using the Drupal logger.
### Testing

To test, with the module enabled, visit some node pages for node types with the color field (articles are recommended)  Then visit the SAPI Data entries page "/admin/structure/sapi/sapi_data" and confirm that frequency is being tracked.  The plugin should maintain one entity per color-user-day combination, and should track hits in the frequency field.

Links: 
- [Trello Card](https://trello.com/c/w9jL6VC8)
- [GitHub branch](https://github.com/james-nesbitt/drupal-sapi2-prototype-demo/tree/demo-sapi-plugin)
