### PR TITLE
Added 'Entity interactions' bundle configuration files

### DIFF
--- a/sapi_demo/config/install/core.entity_form_display.sapi_data.entity_interactions.default.yml
+++ b/sapi_demo/config/install/core.entity_form_display.sapi_data.entity_interactions.default.yml
@@ -1,0 +1,65 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.sapi_data.entity_interactions.field_entity_id
+    - field.field.sapi_data.entity_interactions.field_entity_type
+    - field.field.sapi_data.entity_interactions.field_interaction_type
+    - field.field.sapi_data.entity_interactions.field_user
+    - sapi_data.sapi_data_type.entity_interactions
+  module:
+    - sapi_demo
+id: sapi_data.entity_interactions.default
+targetEntityType: sapi_data
+bundle: entity_interactions
+mode: default
+content:
+  field_entity_id:
+    weight: 13
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: number
+  field_entity_type:
+    weight: 11
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+  field_interaction_type:
+    weight: 14
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: string_textfield
+  field_user:
+    weight: 12
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+    type: entity_reference_autocomplete
+  langcode:
+    type: language_select
+    weight: 10
+    settings: {  }
+    third_party_settings: {  }
+  name:
+    type: string_textfield
+    weight: -4
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  user_id:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/sapi_demo/config/install/core.entity_view_display.sapi_data.entity_interactions.default.yml
+++ b/sapi_demo/config/install/core.entity_view_display.sapi_data.entity_interactions.default.yml
@@ -1,0 +1,60 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.sapi_data.entity_interactions.field_entity_id
+    - field.field.sapi_data.entity_interactions.field_entity_type
+    - field.field.sapi_data.entity_interactions.field_interaction_type
+    - field.field.sapi_data.entity_interactions.field_user
+    - sapi_data.sapi_data_type.entity_interactions
+  module:
+    - user
+    - sapi_demo
+id: sapi_data.entity_interactions.default
+targetEntityType: sapi_data
+bundle: entity_interactions
+mode: default
+content:
+  field_entity_id:
+    weight: 3
+    label: above
+    settings:
+      thousand_separator: ''
+      prefix_suffix: true
+    third_party_settings: {  }
+    type: number_integer
+  field_entity_type:
+    weight: 1
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+  field_interaction_type:
+    weight: 4
+    label: above
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+    type: string
+  field_user:
+    weight: 2
+    label: above
+    settings:
+      link: true
+    third_party_settings: {  }
+    type: entity_reference_label
+  name:
+    label: above
+    type: string
+    weight: -4
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  user_id:
+    label: hidden
+    type: author
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/sapi_demo/config/install/field.field.sapi_data.entity_interactions.field_entity_id.yml
+++ b/sapi_demo/config/install/field.field.sapi_data.entity_interactions.field_entity_id.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.sapi_data.field_entity_id
+    - sapi_data.sapi_data_type.entity_interactions
+  module:
+    - sapi_demo
+id: sapi_data.entity_interactions.field_entity_id
+field_name: field_entity_id
+entity_type: sapi_data
+bundle: entity_interactions
+label: 'Entity ID'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  min: null
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/sapi_demo/config/install/field.field.sapi_data.entity_interactions.field_entity_type.yml
+++ b/sapi_demo/config/install/field.field.sapi_data.entity_interactions.field_entity_type.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.sapi_data.field_entity_type
+    - sapi_data.sapi_data_type.entity_interactions
+  module:
+    - sapi_demo
+id: sapi_data.entity_interactions.field_entity_type
+field_name: field_entity_type
+entity_type: sapi_data
+bundle: entity_interactions
+label: 'Entity type'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/sapi_demo/config/install/field.field.sapi_data.entity_interactions.field_interaction_type.yml
+++ b/sapi_demo/config/install/field.field.sapi_data.entity_interactions.field_interaction_type.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.sapi_data.field_interaction_type
+    - sapi_data.sapi_data_type.entity_interactions
+  module:
+    - sapi_demo
+id: sapi_data.entity_interactions.field_interaction_type
+field_name: field_interaction_type
+entity_type: sapi_data
+bundle: entity_interactions
+label: 'Interaction type'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: string

--- a/sapi_demo/config/install/field.field.sapi_data.entity_interactions.field_user.yml
+++ b/sapi_demo/config/install/field.field.sapi_data.entity_interactions.field_user.yml
@@ -1,0 +1,29 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.sapi_data.field_user
+    - sapi_data.sapi_data_type.entity_interactions
+  module:
+    - sapi_demo
+id: sapi_data.entity_interactions.field_user
+field_name: field_user
+entity_type: sapi_data
+bundle: entity_interactions
+label: User
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:user'
+  handler_settings:
+    include_anonymous: true
+    filter:
+      type: _none
+    target_bundles: null
+    sort:
+      field: _none
+    auto_create: false
+field_type: entity_reference

--- a/sapi_demo/config/install/field.storage.sapi_data.field_entity_id.yml
+++ b/sapi_demo/config/install/field.storage.sapi_data.field_entity_id.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - sapi_data
+    - sapi_demo
+id: sapi_data.field_entity_id
+field_name: field_entity_id
+entity_type: sapi_data
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/sapi_demo/config/install/field.storage.sapi_data.field_entity_type.yml
+++ b/sapi_demo/config/install/field.storage.sapi_data.field_entity_type.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - sapi_data
+    - sapi_demo
+id: sapi_data.field_entity_type
+field_name: field_entity_type
+entity_type: sapi_data
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/sapi_demo/config/install/field.storage.sapi_data.field_interaction_type.yml
+++ b/sapi_demo/config/install/field.storage.sapi_data.field_interaction_type.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - sapi_data
+    - sapi_demo
+id: sapi_data.field_interaction_type
+field_name: field_interaction_type
+entity_type: sapi_data
+type: string
+settings:
+  max_length: 255
+  is_ascii: false
+  case_sensitive: false
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/sapi_demo/config/install/sapi_data.sapi_data_type.entity_interactions.yml
+++ b/sapi_demo/config/install/sapi_data.sapi_data_type.entity_interactions.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - sapi_demo
+id: entity_interactions
+label: 'Entity interactions'


### PR DESCRIPTION
Created custom entity bundle "Entity interactions" with fields:
- Entity type(Plain text)
- Entity ID(Number(int))
- Interaction Type(Plain text)
- User(Entity reference)

After enabling `sapi_demo` module you should be able to add new Entity interaction under `admin/structure/sapi/sapi_data/add/entity_interactions`
Trello card - https://trello.com/c/FpHyHbSw
