### PR TITLE
Created ActionHandler plugin which saves Entity interactions to database

### DIFF
--- a/sapi_demo/src/Plugin/Statistics/ActionHandler/EntityInteractionTracker.php
+++ b/sapi_demo/src/Plugin/Statistics/ActionHandler/EntityInteractionTracker.php
@@ -86,10 +86,10 @@ class EntityInteractionTracker extends ActionHandlerBase implements ActionHandle
     $interaction_type = $action->getAction();
 
     /**
-     * @var string $account
+     * @var string $user_id
      *   UID of user who interacted to Entity
      */
-    $account = $action->getAccount()->id();
+    $user_id = $action->getAccount()->id();
 
     /**
      * @var EntityStorageInterface $sapiDataStorage
@@ -105,7 +105,7 @@ class EntityInteractionTracker extends ActionHandlerBase implements ActionHandle
       'field_entity_type' => $entity_type,
       'field_entity_id' => $entity_id,
       'field_interaction_type' => $interaction_type,
-      'field_user' => $account,
+      'field_user' => $user_id,
     ]);
 
     if (!$sapiData->save()) {

--- a/sapi_demo/src/Plugin/Statistics/ActionHandler/EntityInteractionTracker.php
+++ b/sapi_demo/src/Plugin/Statistics/ActionHandler/EntityInteractionTracker.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Drupal\sapi_demo\Plugin\Statistics\ActionHandler;
+
+use Drupal\sapi\ActionHandlerInterface;
+use Drupal\sapi\ActionHandlerBase;
+use Drupal\sapi\ActionTypeInterface;
+use Drupal\sapi\Plugin\Statistics\ActionType\EntityInteraction;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\Core\Entity\EntityStorageInterface;
+
+/**
+ * This is a SAPI handler plugin used to track any entity interactions (view, update and create).
+ *
+ * @ActionHandler(
+ *  id = "entity_interaction_tracker",
+ *  label = "Track any entity interactions"
+ * )
+ */
+class EntityInteractionTracker extends ActionHandlerBase implements ActionHandlerInterface{
+
+  /**
+   * EntityTypeManager used to get entity storage for sapi_data items, which is
+   * used to create and edit sapi_data items from tracking.
+   *
+   * @protected Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   */
+  protected $entityTypeManager;
+
+  /**
+   * EntityInteractionTracker constructor.
+   *
+   * @param array $configuration
+   * @param string $plugin_id
+   * @param mixed $plugin_definition
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entityTypeManager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+
+    $this->entityTypeManager = $entityTypeManager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function process(ActionTypeInterface $action){
+
+    /**
+     * Only acts if $action is an EntityInteraction plugin type
+     */
+    if (!($action instanceof EntityInteraction)) {
+      return;
+    }
+
+    /**
+     * @var string $entity_type
+     *   Label of Entity
+     */
+    $entity_type = $action->getEntity()->getEntityTypeId();
+
+    /**
+     * @var string $entity_id
+     *   ID of Entity
+     */
+    $entity_id = $action->getEntity()->id();
+
+    /**
+     * @var string $interaction_type
+     *   Interaction type to Entity(View, Update, Create)
+     */
+    $interaction_type = $action->getAction();
+
+    /**
+     * @var string $account
+     *   UID of user who interacted to Entity
+     */
+    $account = $action->getAccount()->id();
+
+    /**
+     * @var EntityStorageInterface $sapiDataStorage
+     */
+    $sapiDataStorage = $this->entityTypeManager->getStorage('sapi_data');
+
+    /** Creating a new interaction entity */
+
+    /** @var \Drupal\sapi_data\SAPIDataInterface $sapiData */
+    $sapiData = $sapiDataStorage->create([
+      'type' => 'entity_interaction',
+      'name' => $entity_type .':'. $entity_id .':'. $interaction_type,
+      'field_entity_type' => $entity_type,
+      'field_entity_id' => $entity_id,
+      'field_interaction_type' => $interaction_type,
+      'field_user' => $account,
+    ]);
+
+    if (!$sapiData->save()) {
+      \Drupal::logger('sapi')->warning('Could not create SAPI data');
+    }
+
+  }
+
+}

--- a/sapi_demo/src/Plugin/Statistics/ActionHandler/EntityInteractionTracker.php
+++ b/sapi_demo/src/Plugin/Statistics/ActionHandler/EntityInteractionTracker.php
@@ -69,7 +69,7 @@ class EntityInteractionTracker extends ActionHandlerBase implements ActionHandle
 
     /**
      * @var string $entity_type
-     *   Label of Entity
+     *   Entity type ID
      */
     $entity_type = $action->getEntity()->getEntityTypeId();
 


### PR DESCRIPTION
Created ActionHandler plugin `EntityInteractionTracker` which saves each Entity interaction to database with these info: 
- Entity type on what was interacted
- Entity ID on what was interacted
- Interaction type on entity
- User id who interacted to entity

Plugin acts only if ActionType plugin `EntityInteraction`  is enabled in Statistics settings form `admin/config/sapi/statistics-plugins`

Trello card - https://trello.com/c/FzU1q3RM
