### PR TITLE
Entity interaction trigger for entity view.

### DIFF
--- a/sapi_demo/sapi_demo.services.yml
+++ b/sapi_demo/sapi_demo.services.yml
@@ -9,4 +9,3 @@ services:
     arguments: ["@current_user", "@sapi.dispatcher", "@plugin.manager.sapi_action_type", "@current_route_match"]
     tags:
       - { name: event_subscriber }
-

--- a/sapi_demo/sapi_demo.services.yml
+++ b/sapi_demo/sapi_demo.services.yml
@@ -4,8 +4,8 @@ services:
     arguments: ['@sapi.dispatcher', '@plugin.manager.sapi_action_type']
     tags:
       - { name: event_subscriber }
-  sapi_demo.event_view_subscriber:
-    class: Drupal\sapi_demo\EventSubscriber\EventViewEntitySubscriber
+  sapi_demo.entity_view_event_subscriber:
+    class: Drupal\sapi_demo\EventSubscriber\EntityViewEventSubscriber
     arguments: ["@current_user", "@sapi.dispatcher", "@plugin.manager.sapi_action_type", "@current_route_match"]
     tags:
       - { name: event_subscriber }

--- a/sapi_demo/sapi_demo.services.yml
+++ b/sapi_demo/sapi_demo.services.yml
@@ -4,3 +4,9 @@ services:
     arguments: ['@sapi.dispatcher', '@plugin.manager.sapi_action_type']
     tags:
       - { name: event_subscriber }
+  sapi_demo.event_view_subscriber:
+    class: Drupal\sapi_demo\EventSubscriber\EventViewEntitySubscriber
+    arguments: ["@current_user", "@sapi.dispatcher", "@plugin.manager.sapi_action_type", "@current_route_match"]
+    tags:
+      - { name: event_subscriber }
+

--- a/sapi_demo/src/EventSubscriber/EntityViewEventSubscriber.php
+++ b/sapi_demo/src/EventSubscriber/EntityViewEventSubscriber.php
@@ -77,7 +77,7 @@ class EntityViewEventSubscriber implements EventSubscriberInterface {
    */
   public function onEventView(Event $event) {
     try {
-      if (preg_match('/entity\.(?:[A-Za-z\-]+)\.canonical/',$this->currentRouteMatch->getRouteName())) {
+      if (preg_match('/entity\.(?:[\w]+)\.canonical/',$this->currentRouteMatch->getRouteName())) {
         /** @var $routeData[] An array of strings containing consecutive parts of route name. */
         $routeData = explode('.',$this->currentRouteMatch->getRouteName());
         /** @var \Drupal\Core\Entity\EntityInterface $entity */

--- a/sapi_demo/src/EventSubscriber/EntityViewEventSubscriber.php
+++ b/sapi_demo/src/EventSubscriber/EntityViewEventSubscriber.php
@@ -77,11 +77,9 @@ class EntityViewEventSubscriber implements EventSubscriberInterface {
    */
   public function onEventView(Event $event) {
     try {
-      if (preg_match('/entity\.(?:[\w]+)\.canonical/',$this->currentRouteMatch->getRouteName())) {
-        /** @var $routeData[] An array of strings containing consecutive parts of route name. */
-        $routeData = explode('.',$this->currentRouteMatch->getRouteName());
+      if (preg_match('/entity\.([\w]+)\.canonical/',$this->currentRouteMatch->getRouteName(), $matches)) {
         /** @var \Drupal\Core\Entity\EntityInterface $entity */
-        $entity = $this->currentRouteMatch->getParameter($routeData[1]);
+        $entity = $this->currentRouteMatch->getParameter($matches[1]);
         /** @var string $mode String containing Display mode. */
         $mode = $event->getControllerResult()['#view_mode'];
         /** @var \Drupal\sapi\ActionTypeInterface $action */

--- a/sapi_demo/src/EventSubscriber/EntityViewEventSubscriber.php
+++ b/sapi_demo/src/EventSubscriber/EntityViewEventSubscriber.php
@@ -14,11 +14,11 @@ use Drupal\sapi\ActionTypeInterface;
 use Drupal\Core\Entity;
 
 /**
- * Class EventViewEntitySubscriber.
+ * Class EntityViewEventSubscriber.
  *
  * @package Drupal\sapi_demo
  */
-class EventViewEntitySubscriber implements EventSubscriberInterface {
+class EntityViewEventSubscriber implements EventSubscriberInterface {
 
   /**
    * Drupal\Core\Session\AccountProxy definition.

--- a/sapi_demo/src/EventSubscriber/EntityViewEventSubscriber.php
+++ b/sapi_demo/src/EventSubscriber/EntityViewEventSubscriber.php
@@ -77,9 +77,9 @@ class EntityViewEventSubscriber implements EventSubscriberInterface {
    */
   public function onEventView(Event $event) {
     try {
-      /** @var $routeData[] An array of strings containing consecutive parts of route name. */
-      $routeData = explode('.',$this->currentRouteMatch->getRouteName());
-      if (in_array('canonical', $routeData)) {
+      if (preg_match('/entity\.(?:[A-Za-z\-]+)\.canonical/',$this->currentRouteMatch->getRouteName())) {
+        /** @var $routeData[] An array of strings containing consecutive parts of route name. */
+        $routeData = explode('.',$this->currentRouteMatch->getRouteName());
         /** @var \Drupal\Core\Entity\EntityInterface $entity */
         $entity = $this->currentRouteMatch->getParameter($routeData[1]);
         /** @var string $mode String containing Display mode. */

--- a/sapi_demo/src/EventSubscriber/EntityViewEventSubscriber.php
+++ b/sapi_demo/src/EventSubscriber/EntityViewEventSubscriber.php
@@ -10,7 +10,6 @@ use Drupal\sapi\Dispatcher;
 use Drupal\Core\Routing\CurrentRouteMatch;
 use Symfony\Component\HttpKernel\KernelEvents;
 use Drupal\sapi\ActionTypeInterface;
-
 use Drupal\Core\Entity;
 
 /**
@@ -74,13 +73,12 @@ class EntityViewEventSubscriber implements EventSubscriberInterface {
    * Informs Statistics API dispatcher when controller outputs a value which is
    * not a Response instance.
    *
-   * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+   * @param \Symfony\Component\HttpKernel\Event\GetResponseForControllerResultEvent $event
    */
   public function onEventView(Event $event) {
     try {
       /** @var $routeData[] An array of strings containing consecutive parts of route name. */
       $routeData = explode('.',$this->currentRouteMatch->getRouteName());
-
       if (in_array('canonical', $routeData)) {
         /** @var \Drupal\Core\Entity\EntityInterface $entity */
         $entity = $this->currentRouteMatch->getParameter($routeData[1]);

--- a/sapi_demo/src/EventSubscriber/EventViewEntitySubscriber.php
+++ b/sapi_demo/src/EventSubscriber/EventViewEntitySubscriber.php
@@ -79,16 +79,16 @@ class EventViewEntitySubscriber implements EventSubscriberInterface {
   public function onEventView(Event $event) {
   try {
     $routeData = explode('.',$this->currentRouteMatch->getRouteName());
-		if ($routeData[2] == 'canonical'){
-			/** @var \Drupal\Core\Entity\EntityInterface $entity */
-			$entity = $this->currentRouteMatch->getParameter($routeData[1]);
-			/** @var \Drupal\sapi\ActionTypeInterface $action */
-			$action = $this->SAPIActionTypeManager->createInstance('entity_interaction', [ 'account'=> $this->currentUser,'entity'=> $entity,'action'=> 'View','mode'=>'full', ]);
-			if (!($action instanceof ActionTypeInterface)) {
-				throw new \Exception('No entity_interaction plugin was found');
-			}
-			$this->sapiDispatcher->dispatch($action);
-		}
+    if ($routeData[2] == 'canonical'){
+      /** @var \Drupal\Core\Entity\EntityInterface $entity */
+      $entity = $this->currentRouteMatch->getParameter($routeData[1]);
+      /** @var \Drupal\sapi\ActionTypeInterface $action */
+      $action = $this->SAPIActionTypeManager->createInstance('entity_interaction', [ 'account'=> $this->currentUser,'entity'=> $entity,'action'=> 'View','mode'=>'full', ]);
+      if (!($action instanceof ActionTypeInterface)) {
+        throw new \Exception('No entity_interaction plugin was found');
+      }
+      $this->sapiDispatcher->dispatch($action);
+    }
   } catch (\Exception $e) {
     watchdog_exception('sapi_demo', $e);
     }

--- a/sapi_demo/src/EventSubscriber/EventViewEntitySubscriber.php
+++ b/sapi_demo/src/EventSubscriber/EventViewEntitySubscriber.php
@@ -71,8 +71,8 @@ class EventViewEntitySubscriber implements EventSubscriberInterface {
   }
 
   /**
-	 * Informs Statistics API dispatcher when controller outputs a value which is
-	 * not a Response instance.
+   * Informs Statistics API dispatcher when controller outputs a value which is
+   * not a Response instance.
    *
    * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
    */
@@ -80,11 +80,14 @@ class EventViewEntitySubscriber implements EventSubscriberInterface {
     try {
       /** @var $routeData[] An array of strings containing consecutive parts of route name. */
       $routeData = explode('.',$this->currentRouteMatch->getRouteName());
-      if (count($routeData) >= 3 && $routeData[0] == 'entity') {
+
+      if (in_array('canonical', $routeData)) {
         /** @var \Drupal\Core\Entity\EntityInterface $entity */
         $entity = $this->currentRouteMatch->getParameter($routeData[1]);
+        /** @var string $mode String containing Display mode. */
+        $mode = $event->getControllerResult()['#view_mode'];
         /** @var \Drupal\sapi\ActionTypeInterface $action */
-        $action = $this->sapiActionTypeManager->createInstance('entity_interaction', ['account'=> $this->currentUser,'entity'=> $entity,'action'=> $routeData[2],'mode'=>'full']);
+        $action = $this->sapiActionTypeManager->createInstance('entity_interaction', ['account'=> $this->currentUser,'entity'=> $entity,'action'=> 'View','mode'=> $mode]);
         if (!($action instanceof ActionTypeInterface)) {
           throw new \Exception('No entity_interaction plugin was found');
         }

--- a/sapi_demo/src/EventSubscriber/EventViewEntitySubscriber.php
+++ b/sapi_demo/src/EventSubscriber/EventViewEntitySubscriber.php
@@ -80,7 +80,7 @@ class EventViewEntitySubscriber implements EventSubscriberInterface {
     try {
       /** @var $routeData[] An array of strings containing consecutive parts of route name. */
       $routeData = explode('.',$this->currentRouteMatch->getRouteName());
-      if (count($routeData) >= 3) {
+      if (count($routeData) >= 3 && $routeData[0] == 'entity') {
         /** @var \Drupal\Core\Entity\EntityInterface $entity */
         $entity = $this->currentRouteMatch->getParameter($routeData[1]);
         /** @var \Drupal\sapi\ActionTypeInterface $action */

--- a/sapi_demo/src/EventSubscriber/EventViewEntitySubscriber.php
+++ b/sapi_demo/src/EventSubscriber/EventViewEntitySubscriber.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Drupal\sapi_demo\EventSubscriber;
+
+use Drupal\Component\Plugin\PluginManagerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\Event;
+use Drupal\Core\Session\AccountProxy;
+use Drupal\sapi\Dispatcher;
+use Drupal\Core\Routing\CurrentRouteMatch;
+use Symfony\Component\HttpKernel\KernelEvents;
+use Drupal\sapi\ActionTypeInterface;
+
+use Drupal\Core\Entity;
+
+/**
+ * Class EventViewEntitySubscriber.
+ *
+ * @package Drupal\sapi_demo
+ */
+class EventViewEntitySubscriber implements EventSubscriberInterface {
+
+  /**
+   * Drupal\Core\Session\AccountProxy definition.
+   *
+   * @var \Drupal\Core\Session\AccountProxy
+   */
+  protected $currentUser;
+
+  /**
+   * Drupal\sapi\Dispatcher definition.
+   *
+   * @var \Drupal\sapi\Dispatcher
+   */
+  protected $sapiDispatcher;
+
+  /**
+   * The statistics action type plugin manager which will be used to create sapi
+   * items to be passed to the dispatcher
+   *
+   * @var \Drupal\Component\Plugin\PluginManagerInterface $SAPIActionTypeManager
+   */
+  protected $SAPIActionTypeManager;
+
+  /**
+   * Drupal\Core\Routing\CurrentRouteMatch definition.
+   *
+   * @var \Drupal\Core\Routing\CurrentRouteMatch
+   */
+  protected $currentRouteMatch;
+
+  /**
+   * Constructor.
+   */
+  public function __construct(AccountProxy $currentUser, Dispatcher $sapiDispatcher, PluginManagerInterface $SAPIActionTypeManager, CurrentRouteMatch $currentRouteMatch) {
+    $this->currentUser = $currentUser;
+    $this->sapiDispatcher = $sapiDispatcher;
+    $this->SAPIActionTypeManager = $SAPIActionTypeManager;
+    $this->currentRouteMatch = $currentRouteMatch;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  static function getSubscribedEvents() {
+    // Priority is set to 1 to avoid this listener from being stopped by other
+    // listeners.
+    // @see ContainerAwareEventDispatcher::dispatch()
+    $events[KernelEvents::VIEW][] = ['onEventView', 1];
+    return $events;
+  }
+
+  /**
+	 * Informs Statistics API dispatcher when controller outputs a value which is
+	 * not a Response instance.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\GetResponseEvent $event
+   */
+  public function onEventView(Event $event) {
+  try {
+    $routeData = explode('.',$this->currentRouteMatch->getRouteName());
+		if ($routeData[2] == 'canonical'){
+			/** @var \Drupal\Core\Entity\EntityInterface $entity */
+			$entity = $this->currentRouteMatch->getParameter($routeData[1]);
+			/** @var \Drupal\sapi\ActionTypeInterface $action */
+			$action = $this->SAPIActionTypeManager->createInstance('entity_interaction', [ 'account'=> $this->currentUser,'entity'=> $entity,'action'=> 'View','mode'=>'full', ]);
+			if (!($action instanceof ActionTypeInterface)) {
+				throw new \Exception('No entity_interaction plugin was found');
+			}
+			$this->sapiDispatcher->dispatch($action);
+		}
+  } catch (\Exception $e) {
+    watchdog_exception('sapi_demo', $e);
+    }
+  }
+
+}


### PR DESCRIPTION
**Created new Drupal/Symfony EventSubscriber that listens to KernelEvents::view.**  

The listener checks the current route to see if it is an entity route, and if so, creates an EntityInteraction ActionType plugin, and dispatches it through the sapi Dispatcher. To capture only entity view action route name is checked for "canonical".

ActionType plugin is provided with:
- currentUser - \Drupal\Core\Session\AccountProxy;
- entity - \Drupal\Core\Entity;
- action - string provided by route;
- mode - string extracted with event->getControllerResult();

[Trello card ](https://trello.com/c/D84k4U1v/33-create-action-triggering-code-that-will-dispatch-an-entity-interaction-action-to-the-dispatcher-whenever-an-entity-is-being-view)
