### PR TITLE
Entity interaction trigger for entity create and update.

### DIFF
--- a/sapi_demo/sapi_demo.module
+++ b/sapi_demo/sapi_demo.module
@@ -26,3 +26,26 @@ function sapi_demo_entity_update(EntityInterface $entity){
   }
   $sapiDispatcher->dispatch($action);
 }
+
+/**
+ * Initiates Drupal\sapi\ActionType plugin and hands it to dispatcher
+ * when entity is created.
+ *
+ * Implements hook_entity_create()
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ */
+function sapi_demo_entity_create(EntityInterface $entity){
+  /** @var \Drupal\Component\Plugin\PluginManagerInterface $actionType */
+  $actionType = \Drupal::service('plugin.manager.sapi_action_type');
+  /** @var \Drupal\Core\Session\AccountProxy $currentUser */
+  $currentUser = \Drupal::service('current_user');
+  /** @var \Drupal\sapi\Dispatcher $sapiDispatcher */
+  $sapiDispatcher = \Drupal::service('sapi.dispatcher');
+  /** @var \Drupal\sapi\ActionTypeInterface $action */
+  $action = $actionType->createInstance('entity_interaction', ['account'=> $currentUser,'entity'=> $entity,'action'=> 'Create','mode'=> '']);
+  if (!($action instanceof ActionTypeInterface)) {
+    throw new \Exception('No entity_interaction plugin was found');
+  }
+  $sapiDispatcher->dispatch($action);
+}

--- a/sapi_demo/sapi_demo.module
+++ b/sapi_demo/sapi_demo.module
@@ -8,9 +8,9 @@ use Drupal\Core\Entity;
  * Initiates Drupal\sapi\ActionType plugin and hands it to dispatcher
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
- * @param string $action Type of action initiated.
+ * @param string $operation Type of operation made on entity.
  */
-function actionTypeTrigger(EntityInterface $entity, $action){
+function actionTypeTrigger(EntityInterface $entity, $operation){
   try {
     /** @var \Drupal\Component\Plugin\PluginManagerInterface $actionType */
     $actionType = \Drupal::service('plugin.manager.sapi_action_type');
@@ -19,7 +19,7 @@ function actionTypeTrigger(EntityInterface $entity, $action){
     /** @var \Drupal\sapi\Dispatcher $sapiDispatcher */
     $sapiDispatcher = \Drupal::service('sapi.dispatcher');
     /** @var \Drupal\sapi\ActionTypeInterface $action */
-    $action = $actionType->createInstance('entity_interaction', ['account'=> $currentUser,'entity'=> $entity,'action'=> 'Update','mode'=> '']);
+    $action = $actionType->createInstance('entity_interaction', ['account'=> $currentUser,'entity'=> $entity,'action'=> $operation,'mode'=> '']);
     if (!($action instanceof ActionTypeInterface)) {
       throw new \Exception('No entity_interaction plugin was found');
     }

--- a/sapi_demo/sapi_demo.module
+++ b/sapi_demo/sapi_demo.module
@@ -42,18 +42,18 @@ function sapi_demo_entity_update(EntityInterface $entity){
 function sapi_demo_entity_insert(EntityInterface $entity) {
   if ($entity->getEntityTypeId() != 'sapi_data') {
     try {
-    /** @var \Drupal\Component\Plugin\PluginManagerInterface $actionType */
-    $actionType = \Drupal::service('plugin.manager.sapi_action_type');
-    /** @var \Drupal\Core\Session\AccountProxy $currentUser */
-    $currentUser = \Drupal::service('current_user');
-    /** @var \Drupal\sapi\Dispatcher $sapiDispatcher */
-    $sapiDispatcher = \Drupal::service('sapi.dispatcher');
-    /** @var \Drupal\sapi\ActionTypeInterface $action */
-    $action = $actionType->createInstance('entity_interaction', ['account'=> $currentUser,'entity'=> $entity,'action'=>'Create','mode'=>'']);
-    if (!($action instanceof ActionTypeInterface)) {
-      drupal_set_message('not instance');
-    }
-    $sapiDispatcher->dispatch($action);
+      /** @var \Drupal\Component\Plugin\PluginManagerInterface $actionType */
+      $actionType = \Drupal::service('plugin.manager.sapi_action_type');
+      /** @var \Drupal\Core\Session\AccountProxy $currentUser */
+      $currentUser = \Drupal::service('current_user');
+      /** @var \Drupal\sapi\Dispatcher $sapiDispatcher */
+      $sapiDispatcher = \Drupal::service('sapi.dispatcher');
+      /** @var \Drupal\sapi\ActionTypeInterface $action */
+      $action = $actionType->createInstance('entity_interaction', ['account'=> $currentUser,'entity'=> $entity,'action'=>'Create','mode'=>'']);
+      if (!($action instanceof ActionTypeInterface)) {
+        throw new \Exception('No entity_interaction plugin was found');
+      }
+      $sapiDispatcher->dispatch($action);
     } catch (\Exception $e) {
       watchdog_exception('sapi_demo', $e);
     }

--- a/sapi_demo/sapi_demo.module
+++ b/sapi_demo/sapi_demo.module
@@ -1,0 +1,28 @@
+<?php
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\sapi\ActionTypeInterface;
+use Drupal\Core\Entity;
+
+/**
+ * Initiates Drupal\sapi\ActionType plugin and hands it to dispatcher
+ * when entity is updated.
+ *
+ * Implements hook_entity_update()
+ *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ */
+function sapi_demo_entity_update(EntityInterface $entity){
+  /** @var \Drupal\Component\Plugin\PluginManagerInterface $actionType */
+  $actionType = \Drupal::service('plugin.manager.sapi_action_type');
+  /** @var \Drupal\Core\Session\AccountProxy $currentUser */
+  $currentUser = \Drupal::service('current_user');
+  /** @var \Drupal\sapi\Dispatcher $sapiDispatcher */
+  $sapiDispatcher = \Drupal::service('sapi.dispatcher');
+  /** @var \Drupal\sapi\ActionTypeInterface $action */
+  $action = $actionType->createInstance('entity_interaction', ['account'=> $currentUser,'entity'=> $entity,'action'=> 'Update','mode'=> '']);
+  if (!($action instanceof ActionTypeInterface)) {
+    throw new \Exception('No entity_interaction plugin was found');
+  }
+  $sapiDispatcher->dispatch($action);
+}

--- a/sapi_demo/sapi_demo.module
+++ b/sapi_demo/sapi_demo.module
@@ -13,39 +13,49 @@ use Drupal\Core\Entity;
  * @param \Drupal\Core\Entity\EntityInterface $entity
  */
 function sapi_demo_entity_update(EntityInterface $entity){
-  /** @var \Drupal\Component\Plugin\PluginManagerInterface $actionType */
-  $actionType = \Drupal::service('plugin.manager.sapi_action_type');
-  /** @var \Drupal\Core\Session\AccountProxy $currentUser */
-  $currentUser = \Drupal::service('current_user');
-  /** @var \Drupal\sapi\Dispatcher $sapiDispatcher */
-  $sapiDispatcher = \Drupal::service('sapi.dispatcher');
-  /** @var \Drupal\sapi\ActionTypeInterface $action */
-  $action = $actionType->createInstance('entity_interaction', ['account'=> $currentUser,'entity'=> $entity,'action'=> 'Update','mode'=> '']);
-  if (!($action instanceof ActionTypeInterface)) {
-    throw new \Exception('No entity_interaction plugin was found');
+  try {
+    /** @var \Drupal\Component\Plugin\PluginManagerInterface $actionType */
+    $actionType = \Drupal::service('plugin.manager.sapi_action_type');
+    /** @var \Drupal\Core\Session\AccountProxy $currentUser */
+    $currentUser = \Drupal::service('current_user');
+    /** @var \Drupal\sapi\Dispatcher $sapiDispatcher */
+    $sapiDispatcher = \Drupal::service('sapi.dispatcher');
+    /** @var \Drupal\sapi\ActionTypeInterface $action */
+    $action = $actionType->createInstance('entity_interaction', ['account'=> $currentUser,'entity'=> $entity,'action'=> 'Update','mode'=> '']);
+    if (!($action instanceof ActionTypeInterface)) {
+      throw new \Exception('No entity_interaction plugin was found');
+    }
+    $sapiDispatcher->dispatch($action);
+  } catch (\Exception $e) {
+    watchdog_exception('sapi_demo', $e);
   }
-  $sapiDispatcher->dispatch($action);
 }
 
 /**
  * Initiates Drupal\sapi\ActionType plugin and hands it to dispatcher
  * when entity is created.
  *
- * Implements hook_entity_create()
+ * Implements hook_entity_insert()
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
  */
-function sapi_demo_entity_create(EntityInterface $entity){
-  /** @var \Drupal\Component\Plugin\PluginManagerInterface $actionType */
-  $actionType = \Drupal::service('plugin.manager.sapi_action_type');
-  /** @var \Drupal\Core\Session\AccountProxy $currentUser */
-  $currentUser = \Drupal::service('current_user');
-  /** @var \Drupal\sapi\Dispatcher $sapiDispatcher */
-  $sapiDispatcher = \Drupal::service('sapi.dispatcher');
-  /** @var \Drupal\sapi\ActionTypeInterface $action */
-  $action = $actionType->createInstance('entity_interaction', ['account'=> $currentUser,'entity'=> $entity,'action'=> 'Create','mode'=> '']);
-  if (!($action instanceof ActionTypeInterface)) {
-    throw new \Exception('No entity_interaction plugin was found');
+function sapi_demo_entity_insert(EntityInterface $entity) {
+  if ($entity->getEntityTypeId() != 'sapi_data') {
+    try {
+    /** @var \Drupal\Component\Plugin\PluginManagerInterface $actionType */
+    $actionType = \Drupal::service('plugin.manager.sapi_action_type');
+    /** @var \Drupal\Core\Session\AccountProxy $currentUser */
+    $currentUser = \Drupal::service('current_user');
+    /** @var \Drupal\sapi\Dispatcher $sapiDispatcher */
+    $sapiDispatcher = \Drupal::service('sapi.dispatcher');
+    /** @var \Drupal\sapi\ActionTypeInterface $action */
+    $action = $actionType->createInstance('entity_interaction', ['account'=> $currentUser,'entity'=> $entity,'action'=>'Create','mode'=>'']);
+    if (!($action instanceof ActionTypeInterface)) {
+      drupal_set_message('not instance');
+    }
+    $sapiDispatcher->dispatch($action);
+    } catch (\Exception $e) {
+      watchdog_exception('sapi_demo', $e);
+    }
   }
-  $sapiDispatcher->dispatch($action);
 }

--- a/sapi_demo/sapi_demo.module
+++ b/sapi_demo/sapi_demo.module
@@ -1,33 +1,6 @@
 <?php
 
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\sapi\ActionTypeInterface;
-use Drupal\Core\Entity;
-
-/**
- * Initiates Drupal\sapi\ActionType plugin and hands it to dispatcher
- *
- * @param \Drupal\Core\Entity\EntityInterface $entity
- * @param string $operation Type of operation made on entity.
- */
-function actionTypeTrigger(EntityInterface $entity, $operation){
-  try {
-    /** @var \Drupal\Component\Plugin\PluginManagerInterface $actionType */
-    $actionType = \Drupal::service('plugin.manager.sapi_action_type');
-    /** @var \Drupal\Core\Session\AccountProxy $currentUser */
-    $currentUser = \Drupal::service('current_user');
-    /** @var \Drupal\sapi\Dispatcher $sapiDispatcher */
-    $sapiDispatcher = \Drupal::service('sapi.dispatcher');
-    /** @var \Drupal\sapi\ActionTypeInterface $action */
-    $action = $actionType->createInstance('entity_interaction', ['account'=> $currentUser,'entity'=> $entity,'action'=> $operation,'mode'=> '']);
-    if (!($action instanceof ActionTypeInterface)) {
-      throw new \Exception('No entity_interaction plugin was found');
-    }
-    $sapiDispatcher->dispatch($action);
-  } catch (\Exception $e) {
-    watchdog_exception('sapi_demo', $e);
-  }
-}
 
 /**
  * Implements hook_entity_update()
@@ -35,7 +8,7 @@ function actionTypeTrigger(EntityInterface $entity, $operation){
  * @param \Drupal\Core\Entity\EntityInterface $entity
  */
 function sapi_demo_entity_update(EntityInterface $entity){
-  actionTypeTrigger($entity, 'Update');
+  \Drupal::service('sapi_demo.entity_interaction_collector')->actionTypeTrigger($entity,'Update');
 }
 
 /**
@@ -45,6 +18,6 @@ function sapi_demo_entity_update(EntityInterface $entity){
  */
 function sapi_demo_entity_insert(EntityInterface $entity) {
   if ($entity->getEntityTypeId() != 'sapi_data') {
-    actionTypeTrigger($entity, 'Create');
+    \Drupal::service('sapi_demo.entity_interaction_collector')->actionTypeTrigger($entity,'Create');
   }
 }

--- a/sapi_demo/sapi_demo.module
+++ b/sapi_demo/sapi_demo.module
@@ -6,13 +6,11 @@ use Drupal\Core\Entity;
 
 /**
  * Initiates Drupal\sapi\ActionType plugin and hands it to dispatcher
- * when entity is updated.
- *
- * Implements hook_entity_update()
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
+ * @param string $action Type of action initiated.
  */
-function sapi_demo_entity_update(EntityInterface $entity){
+function actionTypeTrigger(EntityInterface $entity, $action){
   try {
     /** @var \Drupal\Component\Plugin\PluginManagerInterface $actionType */
     $actionType = \Drupal::service('plugin.manager.sapi_action_type');
@@ -32,30 +30,21 @@ function sapi_demo_entity_update(EntityInterface $entity){
 }
 
 /**
- * Initiates Drupal\sapi\ActionType plugin and hands it to dispatcher
- * when entity is created.
+ * Implements hook_entity_update()
  *
+ * @param \Drupal\Core\Entity\EntityInterface $entity
+ */
+function sapi_demo_entity_update(EntityInterface $entity){
+  actionTypeTrigger($entity, 'Update');
+}
+
+/**
  * Implements hook_entity_insert()
  *
  * @param \Drupal\Core\Entity\EntityInterface $entity
  */
 function sapi_demo_entity_insert(EntityInterface $entity) {
   if ($entity->getEntityTypeId() != 'sapi_data') {
-    try {
-      /** @var \Drupal\Component\Plugin\PluginManagerInterface $actionType */
-      $actionType = \Drupal::service('plugin.manager.sapi_action_type');
-      /** @var \Drupal\Core\Session\AccountProxy $currentUser */
-      $currentUser = \Drupal::service('current_user');
-      /** @var \Drupal\sapi\Dispatcher $sapiDispatcher */
-      $sapiDispatcher = \Drupal::service('sapi.dispatcher');
-      /** @var \Drupal\sapi\ActionTypeInterface $action */
-      $action = $actionType->createInstance('entity_interaction', ['account'=> $currentUser,'entity'=> $entity,'action'=>'Create','mode'=>'']);
-      if (!($action instanceof ActionTypeInterface)) {
-        throw new \Exception('No entity_interaction plugin was found');
-      }
-      $sapiDispatcher->dispatch($action);
-    } catch (\Exception $e) {
-      watchdog_exception('sapi_demo', $e);
-    }
+    actionTypeTrigger($entity, 'Create');
   }
 }

--- a/sapi_demo/sapi_demo.services.yml
+++ b/sapi_demo/sapi_demo.services.yml
@@ -9,3 +9,7 @@ services:
     arguments: ["@current_user", "@sapi.dispatcher", "@plugin.manager.sapi_action_type", "@current_route_match"]
     tags:
       - { name: event_subscriber }
+  sapi_demo.entity_interaction_collector:
+    class: Drupal\sapi_demo\EntityInteractionCollector
+    arguments: ["@current_user", "@sapi.dispatcher", "@plugin.manager.sapi_action_type"]
+

--- a/sapi_demo/src/EntityInteractionCollector.php
+++ b/sapi_demo/src/EntityInteractionCollector.php
@@ -36,8 +36,9 @@ class EntityInteractionCollector {
    * @var \Drupal\sapi\ActionTypeManager
    */
   protected $sapiActionTypeManager;
+
   /**
-   * Constructor.
+   * EntityInteractionCollector constructor.
    */
   public function __construct(AccountProxy $currentUser, Dispatcher $sapiDispatcher, ActionTypeManager $sapiActionTypeManager) {
     $this->currentUser = $currentUser;

--- a/sapi_demo/src/EntityInteractionCollector.php
+++ b/sapi_demo/src/EntityInteractionCollector.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Drupal\sapi_demo;
+
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Session\AccountProxy;
+use Drupal\sapi\ActionTypeInterface;
+use Drupal\sapi\Dispatcher;
+use Drupal\sapi\ActionTypeManager;
+use Drupal\Core\Entity;
+
+/**
+ * Class EntityInteractionCollector.
+ *
+ * @package Drupal\sapi_demo
+ */
+class EntityInteractionCollector {
+
+  /**
+   * Drupal\Core\Session\AccountProxy definition.
+   *
+   * @var \Drupal\Core\Session\AccountProxy
+   */
+  protected $currentUser;
+
+  /**
+   * Drupal\sapi\Dispatcher definition.
+   *
+   * @var \Drupal\sapi\Dispatcher
+   */
+  protected $sapiDispatcher;
+
+  /**
+   * Drupal\sapi\ActionTypeManager definition.
+   *
+   * @var \Drupal\sapi\ActionTypeManager
+   */
+  protected $sapiActionTypeManager;
+  /**
+   * Constructor.
+   */
+  public function __construct(AccountProxy $currentUser, Dispatcher $sapiDispatcher, ActionTypeManager $sapiActionTypeManager) {
+    $this->currentUser = $currentUser;
+    $this->sapiDispatcher = $sapiDispatcher;
+    $this->sapiActionTypeManager = $sapiActionTypeManager;
+  }
+
+  /**
+   * Initiates Drupal\sapi\ActionType plugin and hands it to dispatcher
+   *
+   * @param \Drupal\Core\Entity\EntityInterface $entity
+   * @param string $operation Type of operation made on entity.
+   */
+  function actionTypeTrigger(EntityInterface $entity, $operation){
+    try {
+      /** @var \Drupal\sapi\ActionTypeInterface $action */
+      $action = $this->sapiActionTypeManager->createInstance('entity_interaction', ['account'=> $this->currentUser,'entity'=> $entity,'action'=> $operation,'mode'=> '']);
+      if (!($action instanceof ActionTypeInterface)) {
+        throw new \Exception('No entity_interaction plugin was found');
+      }
+      $this->sapiDispatcher->dispatch($action);
+    } catch (\Exception $e) {
+      watchdog_exception('sapi_demo', $e);
+    }
+  }
+
+}


### PR DESCRIPTION
**Adds two drupal hooks - `hook_entity_insert` and `hook_entity_update` that uses `api_demo.entity_interaction_collector` service to create actionType plugin and pass it to `Dispatcher:dispatch()`. **

Approach used:
1. `api_demo.entity_interaction_collector` method `actionTypeTrigger()` makes use of Drupal\Core\Session\AccountProxy, Drupal\sapi\Dispatcher, Drupal\sapi\ActionTypeManager to create actionType plugin and pass it to `Dispatcher::dispatch()`
2. `hook_entity_insert` and `hook_entity_update` works as triggers that implements `Drupal::service()` method to make use of `EntityInteractionCollector::actionTypeTrigger()` and passes Entity object and type of operation made on entity as a string.
3. `hook_entity_insert` checks if entity that has been created is not 'sapi_data' to avoid infinite loop.

[Trello card -1](https://trello.com/c/brhVFdrl/35-create-action-triggering-code-that-will-dispatch-an-entity-interaction-action-whenever-an-entity-is-updated)
[Trello card -2](https://trello.com/c/zIug5iji/34-create-action-triggering-code-that-will-dispatch-an-entity-interaction-action-whenever-an-entity-is-created)
