### PR TITLE
Hot fix color field empty

### DIFF
--- a/sapi_demo/src/Plugin/Statistics/ActionHandler/ArticleColorTracker.php
+++ b/sapi_demo/src/Plugin/Statistics/ActionHandler/ArticleColorTracker.php
@@ -118,7 +118,12 @@ class ArticleColorTracker extends ActionHandlerBase implements ActionHandlerInte
      * @var int $color
      *   term tid for the colour that we will track
      */
-    $color = $currentNode->get('field_colors')[0]->getValue()['target_id'];
+    if(isset($currentNode->get('field_colors')[0])) {
+      $color = $currentNode->get('field_colors')[0]->getValue()['target_id'];
+    }
+    else {
+      return;
+    }
 
     /**
      * @var int $account

--- a/sapi_demo/src/Plugin/Statistics/ActionHandler/ArticleColorTracker.php
+++ b/sapi_demo/src/Plugin/Statistics/ActionHandler/ArticleColorTracker.php
@@ -114,13 +114,15 @@ class ArticleColorTracker extends ActionHandlerBase implements ActionHandlerInte
       return;
     }
 
+    /** Checks if field_colors has value */
+    if($currentNode->get('field_colors')->isEmpty()) {
+      return;
+    }
+
     /**
      * @var int $color
      *   term tid for the colour that we will track
      */
-    if($currentNode->get('field_colors')->isEmpty()) {
-      return;
-    }
     $color = $currentNode->get('field_colors')[0]->getValue()['target_id'];
 
     /**

--- a/sapi_demo/src/Plugin/Statistics/ActionHandler/ArticleColorTracker.php
+++ b/sapi_demo/src/Plugin/Statistics/ActionHandler/ArticleColorTracker.php
@@ -118,12 +118,10 @@ class ArticleColorTracker extends ActionHandlerBase implements ActionHandlerInte
      * @var int $color
      *   term tid for the colour that we will track
      */
-    if(isset($currentNode->get('field_colors')[0])) {
-      $color = $currentNode->get('field_colors')[0]->getValue()['target_id'];
-    }
-    else {
+    if($currentNode->get('field_colors')->isEmpty()) {
       return;
     }
+    $color = $currentNode->get('field_colors')[0]->getValue()['target_id'];
 
     /**
      * @var int $account


### PR DESCRIPTION
This fix checks if `field_colors` has value. If it's empty, no `sapi_data` entity will be created.

To make sure this work, create new `demo_article` node in `node/add/demo_article`, but leave `Colors` field empty. Make sure, that `article_color_tracker` plugin is enabled in `admin/config/sapi/statistics-plugins`. In databse in `sapi_data` table you will see that after viewing node _without_ color field, no new `sapi_data` entity was created. Viewing node _with_ color field, `sapi_data` entity will be created.

Issue - #18 
