### PR TITLE
Added validation for color field if it has value

### DIFF
--- a/sapi_demo/src/Plugin/Statistics/ActionHandler/ArticleColorTracker.php
+++ b/sapi_demo/src/Plugin/Statistics/ActionHandler/ArticleColorTracker.php
@@ -118,7 +118,12 @@ class ArticleColorTracker extends ActionHandlerBase implements ActionHandlerInte
      * @var int $color
      *   term tid for the colour that we will track
      */
-    $color = $currentNode->get('field_colors')[0]->getValue()['target_id'];
+    if(isset($currentNode->get('field_colors')[0])) {
+      $color = $currentNode->get('field_colors')[0]->getValue()['target_id'];
+    }
+    else {
+      return;
+    }
 
     /**
      * @var int $account

--- a/sapi_demo/src/Plugin/Statistics/ActionHandler/ArticleColorTracker.php
+++ b/sapi_demo/src/Plugin/Statistics/ActionHandler/ArticleColorTracker.php
@@ -114,13 +114,15 @@ class ArticleColorTracker extends ActionHandlerBase implements ActionHandlerInte
       return;
     }
 
+    /** Checks if field_colors has value */
+    if($currentNode->get('field_colors')->isEmpty()) {
+      return;
+    }
+
     /**
      * @var int $color
      *   term tid for the colour that we will track
      */
-    if($currentNode->get('field_colors')->isEmpty()) {
-      return;
-    }
     $color = $currentNode->get('field_colors')[0]->getValue()['target_id'];
 
     /**

--- a/sapi_demo/src/Plugin/Statistics/ActionHandler/ArticleColorTracker.php
+++ b/sapi_demo/src/Plugin/Statistics/ActionHandler/ArticleColorTracker.php
@@ -118,12 +118,10 @@ class ArticleColorTracker extends ActionHandlerBase implements ActionHandlerInte
      * @var int $color
      *   term tid for the colour that we will track
      */
-    if(isset($currentNode->get('field_colors')[0])) {
-      $color = $currentNode->get('field_colors')[0]->getValue()['target_id'];
-    }
-    else {
+    if($currentNode->get('field_colors')->isEmpty()) {
       return;
     }
+    $color = $currentNode->get('field_colors')[0]->getValue()['target_id'];
 
     /**
      * @var int $account


### PR DESCRIPTION
This fix is made for to get rid of fatal error when viewing `demo_article` entity without `colors` field. (Read #18) 
This fix checks if `field_colors` has value `$currentNode->get('field_colors')->isEmpty()`. If it's empty, no `sapi_data` entity will be created and will return nothing.

To make sure this work: 
- Make sure, that article_color_tracker plugin is enabled in `admin/config/sapi/statistics-plugins`. 
- Create two `demo_article` nodes in `node/add/demo_article`, but for one node leave `Colors` field empty. 
- In databse in `sapi_data` table you will see that after viewing node without color field, no new `sapi_data` entity was created. Viewing node with color field, `sapi_data` entity is created.
