### PR TITLE
Created Entity view count list view

### DIFF
--- a/sapi_demo/config/install/views.view.entity_view_count_list.yml
+++ b/sapi_demo/config/install/views.view.entity_view_count_list.yml
@@ -1,0 +1,391 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.sapi_data.field_entity_reference
+    - sapi_data.sapi_data_type.entity_interactions
+    - system.menu.admin
+    - user.role.administrator
+  module:
+    - dynamic_entity_reference
+    - sapi_data
+    - user
+    - sapi_demo
+id: entity_view_count_list
+label: 'Entity view count list'
+module: views
+description: ''
+tag: ''
+base_table: sapi_data
+base_field: id
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: role
+        options:
+          role:
+            administrator: administrator
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: none
+        options:
+          offset: 0
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          override: true
+          sticky: false
+          caption: ''
+          summary: ''
+          description: ''
+          columns:
+            field_entity_reference: field_entity_reference
+            field_entity_reference_2: field_entity_reference_2
+            field_entity_reference_1: field_entity_reference_1
+          info:
+            field_entity_reference:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_entity_reference_2:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            field_entity_reference_1:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          default: field_entity_reference_1
+          empty_table: true
+      row:
+        type: fields
+      fields:
+        field_entity_reference:
+          id: field_entity_reference
+          table: sapi_data__field_entity_reference
+          field: field_entity_reference
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: Entity
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: dynamic_entity_reference_label
+          settings:
+            link: false
+          group_column: target_id
+          group_columns:
+            target_type: target_type
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_entity_reference_2:
+          id: field_entity_reference_2
+          table: sapi_data__field_entity_reference
+          field: field_entity_reference
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: 'Entity Type'
+          exclude: false
+          alter:
+            alter_text: true
+            text: '{{field_entity_reference_2__target_type}}'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_type
+          type: dynamic_entity_reference_label
+          settings:
+            link: true
+          group_column: target_type
+          group_columns:
+            target_id: target_id
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+        field_entity_reference_1:
+          id: field_entity_reference_1
+          table: sapi_data__field_entity_reference
+          field: field_entity_reference
+          relationship: none
+          group_type: count
+          admin_label: ''
+          label: 'View Count'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ', '
+          format_plural: 0
+          format_plural_string: "1\x03@count"
+          prefix: ''
+          suffix: ''
+          click_sort_column: target_id
+          type: dynamic_entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        type:
+          id: type
+          table: sapi_data
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            min: ''
+            max: ''
+            value: ''
+            entity_interactions: entity_interactions
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: sapi_data
+          entity_field: type
+          plugin_id: bundle
+      sorts: {  }
+      title: 'Entity view count list'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments: {  }
+      display_extenders: {  }
+      group_by: true
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.roles
+      tags:
+        - 'config:field.storage.sapi_data.field_entity_reference'
+  page_1:
+    display_plugin: page
+    id: page_1
+    display_title: Page
+    position: 1
+    display_options:
+      display_extenders: {  }
+      path: admin/structure/sapi/entity-view-count-list
+      menu:
+        type: normal
+        title: 'Entity view count list'
+        description: ''
+        expanded: false
+        parent: sapi_data.sapi_data_structure
+        weight: 0
+        context: '0'
+        menu_name: admin
+      tab_options:
+        type: none
+        title: ''
+        description: ''
+        weight: 0
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url.query_args
+        - user.roles
+      tags:
+        - 'config:field.storage.sapi_data.field_entity_reference'

--- a/sapi_demo/config/install/views.view.entity_view_count_list.yml
+++ b/sapi_demo/config/install/views.view.entity_view_count_list.yml
@@ -394,10 +394,10 @@ display:
         - user.roles
       tags:
         - 'config:field.storage.sapi_data.field_entity_reference'
-  page_1:
+  entity_view_count_list:
     display_plugin: page
-    id: page_1
-    display_title: Page
+    id: entity_view_count_list
+    display_title: 'Entity view count list'
     position: 1
     display_options:
       display_extenders: {  }
@@ -416,6 +416,7 @@ display:
         title: ''
         description: ''
         weight: 0
+      display_description: ''
     cache_metadata:
       max-age: 0
       contexts:

--- a/sapi_demo/config/install/views.view.entity_view_count_list.yml
+++ b/sapi_demo/config/install/views.view.entity_view_count_list.yml
@@ -340,6 +340,42 @@ display:
           entity_type: sapi_data
           entity_field: type
           plugin_id: bundle
+        field_interaction_type_value:
+          id: field_interaction_type_value
+          table: sapi_data__field_interaction_type
+          field: field_interaction_type_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: View
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
       sorts: {  }
       title: 'Entity view count list'
       header: {  }


### PR DESCRIPTION
Created view, that shows in table viewed entities, each entity type and view count of entity.
Accessible in `/admin/structure/sapi/entity-view-count-list`

View is allowed to see only to administrator role.

Filters used: 
- Statistics API Data entry: Type - only filtring Entity interactions
- Interaction type - only who have 'View' value

Trello card - https://trello.com/c/SHLNC8ix
