### PR TITLE
Creates Most viewed articles block.

### DIFF
--- a/sapi_demo/config/install/block.block.views_block__most_viewed_articles_last_week_block.yml
+++ b/sapi_demo/config/install/block.block.views_block__most_viewed_articles_last_week_block.yml
@@ -1,0 +1,23 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.most_viewed_articles
+  module:
+    - views
+  theme:
+    - bartik
+id: views_block__most_viewed_articles_last_week_block
+theme: bartik
+region: sidebar_second
+weight: -7
+provider: null
+plugin: 'views_block:most_viewed_articles-most_viewed_articles_last_week_block'
+settings:
+  id: 'views_block:most_viewed_articles-most_viewed_articles_last_week_block'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+visibility: {  }

--- a/sapi_demo/config/install/block.block.views_block__most_viewed_articles_most_viewed_articles_block.yml
+++ b/sapi_demo/config/install/block.block.views_block__most_viewed_articles_most_viewed_articles_block.yml
@@ -7,14 +7,14 @@ dependencies:
     - views
   theme:
     - bartik
-id: views_block__most_viewed_articles_last_week_block
+id: views_block__most_viewed_articles_most_viewed_articles_block
 theme: bartik
 region: sidebar_second
-weight: -7
+weight: -8
 provider: null
-plugin: 'views_block:most_viewed_articles-most_viewed_articles_last_week_block'
+plugin: 'views_block:most_viewed_articles-most_viewed_articles_block'
 settings:
-  id: 'views_block:most_viewed_articles-most_viewed_articles_last_week_block'
+  id: 'views_block:most_viewed_articles-most_viewed_articles_block'
   label: ''
   provider: views
   label_display: visible

--- a/sapi_demo/config/install/views.view.most_viewed_articles.yml
+++ b/sapi_demo/config/install/views.view.most_viewed_articles.yml
@@ -1,19 +1,17 @@
 langcode: en
 status: true
 dependencies:
-  config:
-    - node.type.article
-    - sapi_data.sapi_data_type.entity_interactions
   module:
     - node
     - sapi_data
+    - user
 id: most_viewed_articles
 label: 'Most viewed articles'
 module: views
 description: 'List of the most viewed node-articles for last week (the last seven days)'
 tag: ''
-base_table: sapi_data
-base_field: id
+base_table: node_field_data
+base_field: nid
 core: 8.x
 display:
   default:
@@ -23,8 +21,9 @@ display:
     position: 0
     display_options:
       access:
-        type: none
-        options: {  }
+        type: perm
+        options:
+          perm: 'access content'
       cache:
         type: tag
         options: {  }
@@ -53,14 +52,6 @@ display:
           offset: 0
       style:
         type: default
-        options:
-          grouping:
-            -
-              field: view_node
-              rendered: true
-              rendered_strip: false
-          row_class: ''
-          default_row_class: true
       row:
         type: fields
       fields:
@@ -68,14 +59,17 @@ display:
           id: title
           table: node_field_data
           field: title
-          relationship: node__field_entity_reference
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
           group_type: group
           admin_label: ''
           label: ''
           exclude: false
           alter:
             alter_text: false
-            text: '{{ title }} Viewed: {{ nid }} times'
+            text: ''
             make_link: false
             path: ''
             absolute: false
@@ -104,7 +98,7 @@ display:
           element_class: ''
           element_label_type: ''
           element_label_class: ''
-          element_label_colon: false
+          element_label_colon: true
           element_wrapper_type: ''
           element_wrapper_class: ''
           element_default_classes: true
@@ -114,8 +108,6 @@ display:
           hide_alter_empty: true
           click_sort_column: value
           type: string
-          settings:
-            link_to_entity: true
           group_column: value
           group_columns: {  }
           group_rows: true
@@ -126,21 +118,18 @@ display:
           multi_type: separator
           separator: ', '
           field_api_classes: false
-          entity_type: node
-          entity_field: title
-          plugin_id: field
         nid:
           id: nid
           table: node_field_data
           field: nid
-          relationship: node__field_entity_reference
+          relationship: none
           group_type: count
           admin_label: ''
           label: ''
           exclude: false
           alter:
             alter_text: true
-            text: 'Viewed: {{ nid }} times.'
+            text: 'Viewed: {{ nid }} times in last 7 days.'
             make_link: false
             path: ''
             absolute: false
@@ -187,12 +176,10 @@ display:
           suffix: ''
           click_sort_column: value
           type: number_integer
-          settings:
-            thousand_separator: ''
-            prefix_suffix: true
+          settings: {  }
           group_column: entity_id
           group_columns:
-            value: value
+            entity_id: entity_id
           group_rows: true
           delta_limit: 0
           delta_offset: 0
@@ -204,56 +191,22 @@ display:
           entity_field: nid
           plugin_id: field
       filters:
-        type:
-          id: type
-          table: sapi_data
-          field: type
-          value:
-            entity_interactions: entity_interactions
-          entity_type: sapi_data
-          entity_field: type
-          plugin_id: bundle
-        field_interaction_type_value:
-          id: field_interaction_type_value
-          table: sapi_data__field_interaction_type
-          field: field_interaction_type_value
-          relationship: none
-          group_type: group
-          admin_label: ''
-          operator: '='
-          value: View
-          group: 1
-          exposed: false
+        status:
+          value: true
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
           expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
             operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          plugin_id: string
+          group: 1
         created:
           id: created
           table: sapi_data
           field: created
-          relationship: none
+          relationship: reverse__sapi_data__field_entity_reference
           group_type: group
           admin_label: ''
           operator: '>'
@@ -291,52 +244,12 @@ display:
           entity_type: sapi_data
           entity_field: created
           plugin_id: date
-        type_1:
-          id: type_1
-          table: node_field_data
-          field: type
-          relationship: node__field_entity_reference
-          group_type: group
-          admin_label: ''
-          operator: in
-          value:
-            article: article
-          group: 1
-          exposed: false
-          expose:
-            operator_id: ''
-            label: ''
-            description: ''
-            use_operator: false
-            operator: ''
-            identifier: ''
-            required: false
-            remember: false
-            multiple: false
-            remember_roles:
-              authenticated: authenticated
-            reduce: false
-          is_grouped: false
-          group_info:
-            label: ''
-            description: ''
-            identifier: ''
-            optional: true
-            widget: select
-            multiple: false
-            remember: false
-            default_group: All
-            default_group_multiple: {  }
-            group_items: {  }
-          entity_type: node
-          entity_field: type
-          plugin_id: bundle
       sorts:
         nid:
           id: nid
           table: node_field_data
           field: nid
-          relationship: node__field_entity_reference
+          relationship: none
           group_type: count
           admin_label: ''
           order: DESC
@@ -346,44 +259,47 @@ display:
           entity_type: node
           entity_field: nid
           plugin_id: standard
-      title: 'Most viewed articles'
+      title: 'Most viewed article'
       header: {  }
       footer: {  }
       empty: {  }
       relationships:
-        node__field_entity_reference:
-          id: node__field_entity_reference
-          table: sapi_data__field_entity_reference
-          field: node__field_entity_reference
+        reverse__sapi_data__field_entity_reference:
+          id: reverse__sapi_data__field_entity_reference
+          table: node_field_data
+          field: reverse__sapi_data__field_entity_reference
           relationship: none
           group_type: group
-          admin_label: 'field_entity_reference: Content'
-          required: true
-          plugin_id: standard
+          admin_label: field_entity_reference
+          required: false
+          entity_type: node
+          plugin_id: entity_reverse
       arguments: {  }
       display_extenders: {  }
       group_by: true
-      link_url: ''
-      link_display: '0'
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
       tags: {  }
-  most_viewed_articles_last_week_block:
+  most_viewed_articles_block:
     display_plugin: block
-    id: most_viewed_articles_last_week_block
+    id: most_viewed_articles_block
     display_title: 'Most viewed articles block'
     position: 1
     display_options:
       display_extenders: {  }
-      display_description: 'Most viewed articles for last 7 days.'
       block_description: 'Most viewed articles (last week)'
+      display_description: 'Most viewed articles for last 7 days.'
       block_hide_empty: true
     cache_metadata:
       max-age: -1
       contexts:
         - 'languages:language_content'
         - 'languages:language_interface'
+        - 'user.node_grants:view'
+        - user.permissions
       tags: {  }

--- a/sapi_demo/config/install/views.view.most_viewed_articles.yml
+++ b/sapi_demo/config/install/views.view.most_viewed_articles.yml
@@ -1,0 +1,389 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - node.type.article
+    - sapi_data.sapi_data_type.entity_interactions
+  module:
+    - node
+    - sapi_data
+id: most_viewed_articles
+label: 'Most viewed articles'
+module: views
+description: 'List of the most viewed node-articles for last week (the last seven days)'
+tag: ''
+base_table: sapi_data
+base_field: id
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: none
+        options: {  }
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 5
+          offset: 0
+      style:
+        type: default
+        options:
+          grouping:
+            -
+              field: view_node
+              rendered: true
+              rendered_strip: false
+          row_class: ''
+          default_row_class: true
+      row:
+        type: fields
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          relationship: node__field_entity_reference
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: '{{ title }} Viewed: {{ nid }} times'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          entity_type: node
+          entity_field: title
+          plugin_id: field
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: node__field_entity_reference
+          group_type: count
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: true
+            text: 'Viewed: {{ nid }} times.'
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          set_precision: false
+          precision: 0
+          decimal: .
+          separator: ', '
+          format_plural: 0
+          format_plural_string: "1\x03@count"
+          prefix: ''
+          suffix: ''
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: entity_id
+          group_columns:
+            value: value
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          field_api_classes: false
+          entity_type: node
+          entity_field: nid
+          plugin_id: field
+      filters:
+        type:
+          id: type
+          table: sapi_data
+          field: type
+          value:
+            entity_interactions: entity_interactions
+          entity_type: sapi_data
+          entity_field: type
+          plugin_id: bundle
+        field_interaction_type_value:
+          id: field_interaction_type_value
+          table: sapi_data__field_interaction_type
+          field: field_interaction_type_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: View
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          plugin_id: string
+        created:
+          id: created
+          table: sapi_data
+          field: created
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '>'
+          value:
+            min: ''
+            max: ''
+            value: '-7 days'
+            type: offset
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: sapi_data
+          entity_field: created
+          plugin_id: date
+        type_1:
+          id: type_1
+          table: node_field_data
+          field: type
+          relationship: node__field_entity_reference
+          group_type: group
+          admin_label: ''
+          operator: in
+          value:
+            article: article
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: node
+          entity_field: type
+          plugin_id: bundle
+      sorts:
+        nid:
+          id: nid
+          table: node_field_data
+          field: nid
+          relationship: node__field_entity_reference
+          group_type: count
+          admin_label: ''
+          order: DESC
+          exposed: false
+          expose:
+            label: ''
+          entity_type: node
+          entity_field: nid
+          plugin_id: standard
+      title: 'Most viewed articles'
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships:
+        node__field_entity_reference:
+          id: node__field_entity_reference
+          table: sapi_data__field_entity_reference
+          field: node__field_entity_reference
+          relationship: none
+          group_type: group
+          admin_label: 'field_entity_reference: Content'
+          required: true
+          plugin_id: standard
+      arguments: {  }
+      display_extenders: {  }
+      group_by: true
+      link_url: ''
+      link_display: '0'
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+      tags: {  }
+  most_viewed_articles_last_week_block:
+    display_plugin: block
+    id: most_viewed_articles_last_week_block
+    display_title: 'Most viewed articles block'
+    position: 1
+    display_options:
+      display_extenders: {  }
+      display_description: 'Most viewed articles for last 7 days.'
+      block_description: 'Most viewed articles (last week)'
+      block_hide_empty: true
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+      tags: {  }


### PR DESCRIPTION
## Created last week's most viewed article lists block

Most viewed articles block lists top 5 viewed article nodes and by default resides in Bartick's themes secondary menu.

Approach: 
- List Statistics API Data entry( Entity interaction type) and add a relationship with referenced content;
- For fields to display use content title and aggregate content id field which is then rewritten to display view count;
- Fields then are filtered by Interaction type (View) ,SAPI Data creation date (last 7 days) and content type(article).
- Fields are sorted by count in descending way;
- Block is set to hide if the view output is empty and stripped from any access check.

[Trello card](https://trello.com/c/eOk0Di96/26-as-an-anonymous-user-i-want-to-see-a-list-of-the-most-viewed-node-articles-for-last-week-the-last-seven-days-to-see-what-popular)
